### PR TITLE
Allow serverUrl to override hostname for request

### DIFF
--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -49,8 +49,9 @@ export class NodeClient implements Client<Options> {
       events: [event],
     });
 
+    const hostname = this._options.serverUrl || AMPLITUDE_API_HOST
     const requestOptions = {
-      hostname: AMPLITUDE_API_HOST,
+      hostname: hostname,
       path: AMPLITUDE_API_PATH,
       method: 'POST',
       headers: {


### PR DESCRIPTION
This lets us use api2.amplitude.com to avoid SSL errors on some machines.