### PR TITLE
Add (single) Retry Buffer event queue for events that didn't successfully send

### DIFF
--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -62,6 +62,8 @@ export class NodeClient implements Client<Options> {
       if (response.status === Status.Success) {
         // Clean up the events
         this._events.splice(0, arrayLength);
+      } else {
+        throw new Error(response.status);
       }
     } catch {
       const failedEvents = this._events.slice(0, arrayLength);
@@ -188,13 +190,13 @@ export class NodeClient implements Client<Options> {
           // Clean up the events
           this._eventsToRetry.splice(0, arrayLength);
           this._updateRetryIdSet();
-
           // Successfully sent the events, stop trying
           break;
+        } else {
+          throw new Error(response.status);
         }
       } catch {
-        // Do nothing if there is a failure, go on to next retry loop
-      } finally {
+        // Go on to next retry loop
         numRetries += 1;
       }
     }

--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -183,6 +183,7 @@ export class NodeClient implements Client<Options> {
   private async _retryEvents(numEvents: number): Promise<void> {
     if (this._retryInProgress) {
       // If we are already retrying events, let that loop handle the retrying
+      // Do nothing
       return;
     }
 
@@ -218,14 +219,14 @@ export class NodeClient implements Client<Options> {
     }
 
     // We know that we've tried the first numEvents numbers for the maximum number of tries. kick them out
-    // wait to make sure there are no uploads in progress
     this._eventsToRetry.splice(0, numEvents);
     this._updateRetryIdSet();
     const numEventsRemaining = this._eventsToRetry.length;
     this._retryInProgress = false;
 
     if (numEventsRemaining > 0) {
-      // if more events came in during this time, retry them on a new loop
+      // if more events came in during this time,
+      // retry them on a new loop
       this._retryEvents(numEventsRemaining);
     }
   }

--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -1,4 +1,4 @@
-import { Client, Event, Options, Transport, TransportOptions, Payload, Response, Status } from '@amplitude/types';
+import { Client, Event, Options, Transport, TransportOptions, Payload, Status } from '@amplitude/types';
 import { SDK_NAME, SDK_VERSION, AMPLITUDE_SERVER_URL } from './constants';
 import { logger } from '@amplitude/utils';
 import { HTTPTransport } from './transports';
@@ -13,6 +13,9 @@ export class NodeClient implements Client<Options> {
   private _events: Event[];
   private _transport: Transport;
   private _flushTimer: number = 0;
+  private _uploadInProgress: boolean = false;
+  private _eventsToRetry: Event[];
+  private _idsToRetry: Set<string>;
 
   /**
    * Initializes this client instance.
@@ -24,6 +27,8 @@ export class NodeClient implements Client<Options> {
     this._apiKey = apiKey;
     this._options = options;
     this._events = [];
+    this._eventsToRetry = [];
+    this._idsToRetry = new Set<string>();
     this._transport = this._setupTransport();
     if (options.debug || options.logLevel) {
       logger.enable(options.logLevel);
@@ -40,25 +45,55 @@ export class NodeClient implements Client<Options> {
   /**
    * @inheritDoc
    */
-  public async flush(): Promise<Response> {
+  public async flush(): Promise<void> {
     // Clear the timeout
     clearTimeout(this._flushTimer);
 
+    // If there's an upload currently in progress, wait for it to finish first.
+    await this._waitForUpload();
+
     // Check if there's 0 events, flush is not needed.
-    const arraryLength = this._events.length;
-    if (arraryLength === 0) {
-      return { status: Status.Success, statusCode: 200 };
+    const arrayLength = this._events.length;
+    if (arrayLength === 0) {
+      return;
     }
 
-    const response = this._transport.sendPayload(this._getCurrentPayload());
-    response.then(res => {
-      if (res.status === Status.Success) {
+    this._uploadInProgress = true;
+    try {
+      const response = await this._transport.sendPayload(this._getCurrentPayload());
+      if (response.status === Status.Success) {
         // Clean up the events
-        this._events.splice(0, arraryLength);
+        this._events.splice(0, arrayLength);
       }
-    });
+    } catch {
+      const failedEvents = this._events.slice(0, arrayLength);
+      failedEvents.forEach(event => {
+        if (typeof event.user_id === 'string') {
+          this._idsToRetry.add(event.user_id);
+        } else if (typeof event.device_id === 'string') {
+          this._idsToRetry.add(event.device_id);
+        }
+        // events should either have user or device id
+      });
 
-    return response;
+      const events: Array<Event> = [];
+      const eventsToRetry: Array<Event> = [];
+      this._events.forEach(event => {
+        let hasId = this._idsToRetry.has(event.user_id ?? event.device_id ?? '');
+
+        if (hasId) {
+          eventsToRetry.push(event);
+        } else {
+          events.push(event);
+        }
+      });
+
+      this._events = events;
+      this._eventsToRetry = eventsToRetry;
+      this._retryEvents();
+    } finally {
+      this._uploadInProgress = false;
+    }
   }
 
   /**
@@ -71,9 +106,13 @@ export class NodeClient implements Client<Options> {
 
     this._annotateEvent(event);
     // Add event to unsent events queue.
-    this._events.push(event);
+    if (this._idsToRetry.has(event.user_id ?? event.device_id ?? '')) {
+      this._eventsToRetry.push(event);
+    } else {
+      this._events.push(event);
+    }
 
-    const bufferLimit = this._options.maxCachedEvents || 100;
+    const bufferLimit = this._options.maxCachedEvents ?? 100;
 
     if (this._events.length >= bufferLimit) {
       // # of events exceeds the limit, flush them.
@@ -109,5 +148,63 @@ export class NodeClient implements Client<Options> {
       api_key: this._apiKey,
       events: this._events,
     };
+  }
+
+  private _getRetryPayload(): Payload {
+    return {
+      api_key: this._apiKey,
+      events: this._eventsToRetry,
+    };
+  }
+
+  private async _waitForUpload(): Promise<void> {
+    return new Promise(resolve => {
+      let interval = 0;
+      interval = (setInterval(() => {
+        if (!this._uploadInProgress) {
+          clearInterval(interval);
+          resolve();
+        }
+      }, 1) as any) as number;
+    });
+  }
+
+  private async _retryEvents(): Promise<void> {
+    let numRetries = 0;
+
+    while (numRetries < 5) {
+      // If there's an upload currently in progress, wait for it to finish first.
+      await this._waitForUpload();
+      const numEvents = this._eventsToRetry.length;
+      if (numEvents === 0) {
+        return;
+      }
+
+      this._uploadInProgress = true;
+
+      try {
+        const response = await this._transport.sendPayload(this._getRetryPayload());
+        if (response.status === Status.Success) {
+          // Clean up the events
+          this._eventsToRetry.splice(0, numEvents);
+          this._idsToRetry = this._eventsToRetry.reduce((idSet, event) => {
+            if (event.user_id) {
+              idSet.add(event.user_id);
+            } else if (event.device_id) {
+              idSet.add(event.device_id);
+            }
+            return idSet;
+          }, new Set<string>());
+
+          // Successfully sent the events, stop trying
+          return;
+        }
+      } catch {
+        // Do nothing if there is a failure, go on to next retry loop
+      } finally {
+        this._uploadInProgress = false;
+        numRetries += 1;
+      }
+    }
   }
 }

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -34,5 +34,6 @@ export interface Options {
    */
   debug?: boolean;
 
+  /** The maximum number of times a server will attempt to retry  */
   maxRetries?: number;
 }

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -33,4 +33,6 @@ export interface Options {
    * logLevel is not specified.
    */
   debug?: boolean;
+
+  maxRetries?: number;
 }


### PR DESCRIPTION
Add a single list of events for events that didn't send successfully the first time around.

Eventually, to be refactored to support multiple lists (to separate per user id)