### PR TITLE
Stricten the Options type, pass in partial options

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -1,4 +1,11 @@
+import { Options, LogLevel } from '@amplitude/types';
 export const SDK_NAME = 'amplitude-node';
 export const SDK_VERSION = '0.3.3';
 export const AMPLITUDE_API_HOST = 'api.amplitude.com';
 export const AMPLITUDE_API_PATH = '/2/httpapi';
+export const DEFAULT_OPTIONS: Options = {
+  optOut: false,
+  serverUrl: AMPLITUDE_API_HOST,
+  logLevel: LogLevel.None,
+  debug: false,
+};

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -8,7 +8,7 @@ import { NodeClient } from './nodeClient';
  * @param apiKey API Key for project.
  * @param options Options to pass to the client.
  */
-export function init(apiKey: string, options: Options = {}): NodeClient {
+export function init(apiKey: string, options: Partial<Options> = {}): NodeClient {
   const nodeClient = new NodeClient(apiKey, options);
   return nodeClient;
 }

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -7,12 +7,12 @@ export interface Options {
   /**
    * Whether you opt out from sending events.
    */
-  optOut?: boolean;
+  optOut: boolean;
 
   /**
    * @deprecated Set it if you are using proxy server.
    */
-  serverUrl?: string;
+  serverUrl: string;
 
   /**
    * Configuration of the logging verbosity of the SDK.
@@ -21,12 +21,12 @@ export interface Options {
    * 2 = WARN: Warnings will be generated around dangerous/deprecated features.
    * 3 = VERBOSE: All SDK actions will be logged.
    */
-  logLevel?: LogLevel;
+  logLevel: LogLevel;
 
   /**
    * Whether or not the SDK should be started in debug mode.
    * This will enable the SDK to generate logs at WARN level or above, if the
    * logLevel is not specified.
    */
-  debug?: boolean;
+  debug: boolean;
 }


### PR DESCRIPTION
Changing the typing of what the node client takes in as a `Partial<Options>` type and then adding a `DEFAULT_OPTIONS` constant.