### PR TITLE
Allow transport layer to surface information from the http v2 api, type the response bodies

### DIFF
--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -140,13 +140,19 @@ export class HTTPTransport implements Transport {
         const status = Status.fromHttpCode(statusCode);
 
         res.setEncoding('utf8');
-
+        const data: Array<Buffer> = [];
         resolve({ status, statusCode });
         // Force the socket to drain
-        res.on('data', () => {
-          // Drain
+        res.on('data', chunk => {
+          data.push(chunk);
         });
         res.on('end', () => {
+          if (res.complete) {
+            const body = JSON.parse(Buffer.concat(data).toString('utf8'));
+            resolve({ status, statusCode, body });
+          } else {
+            resolve({ status, statusCode });
+          }
           // Drain
         });
       });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,7 +2,7 @@ export { LogLevel } from './logger';
 export { Client } from './client';
 export { Event, Payload } from './event';
 export { Options } from './options';
-export { Response } from './response';
+export { Response, ResponseBody, mapJSONToResponse } from './response';
 export { RetryClass } from './retry';
 export { Status } from './status';
 export { Transport, TransportOptions } from './transport';

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -1,7 +1,83 @@
 import { Status } from './status';
 
+export type SuccessBody = {
+  code: 200;
+  eventsIngested: number;
+  payloadSizeBytes: number;
+  serverUploadTime: number;
+};
+
+export type InvalidRequestBody = {
+  code: 400;
+  error: string;
+  missingField: string;
+  eventsWithInvalidFields: Array<number>;
+  eventsWithMissingFields: Array<number>;
+};
+
+export type PayloadTooLargeBody = {
+  code: 413;
+  error: string;
+};
+
+export type RateLimitBody = {
+  code: 429;
+  error: string;
+  epsThreshold: number;
+  throttledDevices: { [deviceId: string]: number };
+  throttledUsers: { [userId: string]: number };
+  exceededDailyQuotaDevices: { [userId: string]: number };
+  exceededDailyQuotaUsers: { [userId: string]: number };
+  throttledEvents: Array<number>;
+};
+
+export type ResponseBody = SuccessBody | InvalidRequestBody | PayloadTooLargeBody | RateLimitBody;
+
+export const mapJSONToResponse = (json: any): ResponseBody | null => {
+  if (typeof json !== 'object') {
+    return null;
+  }
+
+  switch (json.code) {
+    case 200:
+      return {
+        code: 200,
+        eventsIngested: json.events_ingested,
+        payloadSizeBytes: json.payload_size_bytes,
+        serverUploadTime: json.server_upload_time,
+      };
+    case 400:
+      return {
+        code: 400,
+        error: json.error ?? '',
+        missingField: json.missing_field,
+        eventsWithInvalidFields: json.events_with_invalid_fields ?? [],
+        eventsWithMissingFields: json.events_with_missing_fields ?? [],
+      };
+    case 413:
+      return {
+        code: 413,
+        error: json.error ?? '',
+      };
+    case 429:
+      return {
+        code: 429,
+        error: json.error ?? '',
+        epsThreshold: json.eps_threshold,
+        throttledDevices: json.throttled_devices ?? {},
+        throttledUsers: json.throttled_users ?? {},
+        exceededDailyQuotaDevices: json.exceeded_daily_quota_devices ?? {},
+        exceededDailyQuotaUsers: json.exceeded_daily_quota_users ?? {},
+        throttledEvents: json.throttled_events ?? [],
+      };
+    default:
+      return null;
+  }
+};
+
 /** JSDoc */
 export interface Response {
   status: Status;
   statusCode: number;
+  body?: ResponseBody;
 }

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -1,5 +1,6 @@
 import { Status } from './status';
 
+/** A response body for a request that returned 200 (successful). */
 export type SuccessBody = {
   code: 200;
   eventsIngested: number;
@@ -7,6 +8,7 @@ export type SuccessBody = {
   serverUploadTime: number;
 };
 
+/** A response body for a request that returned 413 (invalid request). */
 export type InvalidRequestBody = {
   code: 400;
   error: string;
@@ -15,22 +17,25 @@ export type InvalidRequestBody = {
   eventsWithMissingFields: Array<number>;
 };
 
+/** A response body for a request that returned 413 (payload too large). */
 export type PayloadTooLargeBody = {
   code: 413;
   error: string;
 };
 
+/** A response body for a request that returned 429 (rate limit). */
 export type RateLimitBody = {
   code: 429;
   error: string;
   epsThreshold: number;
   throttledDevices: { [deviceId: string]: number };
   throttledUsers: { [userId: string]: number };
-  exceededDailyQuotaDevices: { [userId: string]: number };
+  exceededDailyQuotaDevices: { [deviceId: string]: number };
   exceededDailyQuotaUsers: { [userId: string]: number };
   throttledEvents: Array<number>;
 };
 
+/** Represents additional data that is provided by the http v2 API */
 export type ResponseBody = SuccessBody | InvalidRequestBody | PayloadTooLargeBody | RateLimitBody;
 
 export const mapJSONToResponse = (json: any): ResponseBody | null => {

--- a/packages/types/src/retry.ts
+++ b/packages/types/src/retry.ts
@@ -1,7 +1,7 @@
 import { Event } from './event';
 import { Response } from './response';
 
-/** Transport used sending data to Amplitude */
+/** Layer used to send data to Amplitude while retrying throttled events in the right order.  */
 export interface RetryClass {
   /**
    * Send the events payload to Amplitude, and retry the events that failed on a loop.

--- a/packages/types/src/status.ts
+++ b/packages/types/src/status.ts
@@ -6,8 +6,10 @@ export enum Status {
   Skipped = 'skipped',
   /** The event was sent successfully. */
   Success = 'success',
-  /** The client is currently rate limited and will try again later. */
+  /** A user or device in the payload is currently rate limited and should try again later. */
   RateLimit = 'rate_limit',
+  /** The sent payload was too large to be processed. */
+  PayloadTooLarge = 'payload_too_large',
   /** The event could not be processed. */
   Invalid = 'invalid',
   /** A server-side error ocurred during submission. */
@@ -29,6 +31,10 @@ export namespace Status {
 
     if (code === 429) {
       return Status.RateLimit;
+    }
+
+    if (code === 413) {
+      return Status.PayloadTooLarge;
     }
 
     if (code >= 400 && code < 500) {


### PR DESCRIPTION
creates types for the body for the [http v2 api](https://developers.amplitude.com/docs/batch-event-upload-api#payloadtoolargeerror) and some helper functions to surface that from the transport layer.

Adds the 413 (Payload too large) error to the list of statuses that could be returned.