### PR TITLE
Better Handling of Invalid Events

### DIFF
--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -171,7 +171,9 @@ export class RetryHandler {
           const invalidEventIndices = collectInvalidEventIndices(response);
           // Reverse the indices so that splicing doesn't cause any indexing issues.
           invalidEventIndices.reverse().forEach((index: number) => {
-            eventsBuffer.splice(index, 1);
+            if (index < eventCount) {
+              eventsBuffer.splice(index, 1);
+            }
           });
           // and remove them from the # of events we send
           eventCount -= invalidEventIndices.length;

--- a/packages/node/test/mocks/retry.ts
+++ b/packages/node/test/mocks/retry.ts
@@ -16,29 +16,29 @@ const DEFAULT_RESPONSE_BODY: ResponseBody = {
 };
 
 export class MockThrottledTransport implements Transport {
-  private _throttledId: string;
+  private _failingId: string;
   private _responseBody: ResponseBody;
   private _statusCode: number;
   private _status: Status;
 
-  // The number of payloads that got throttled
-  public throttleCount: number = 0;
-  // The number of payloads that did not get throttled
-  public unthrottleCount: number = 0;
-  public constructor(throttledId: string, response: ResponseBody | null) {
-    this._throttledId = throttledId;
+  // The number of payloads that got failed
+  public failCount: number = 0;
+  // The number of payloads that "passed" to the server
+  public passCount: number = 0;
+  public constructor(failingId: string, response: ResponseBody | null) {
+    this._failingId = failingId;
     this._responseBody = response ?? DEFAULT_RESPONSE_BODY;
     this._statusCode = this._responseBody.code;
     this._status = Status.fromHttpCode(this._statusCode);
   }
 
   public sendPayload(payload: Payload): Promise<Response> {
-    const isMatch = payload.events.some(event => event.user_id === this._throttledId);
+    const isMatch = payload.events.some(event => event.user_id === this._failingId);
     if (isMatch) {
-      this.throttleCount += 1;
+      this.failCount += 1;
       return Promise.resolve({ status: this._status, statusCode: this._statusCode, body: this._responseBody });
     } else {
-      this.unthrottleCount += 1;
+      this.passCount += 1;
       return Promise.resolve({ status: Status.Success, statusCode: 200 });
     }
   }

--- a/packages/node/test/mocks/retry.ts
+++ b/packages/node/test/mocks/retry.ts
@@ -1,24 +1,42 @@
 import { RetryHandler } from '../../src/';
-import { Transport, Payload, Status, Response } from '@amplitude/types';
+import { Transport, Payload, Status, Response, ResponseBody } from '@amplitude/types';
 
 // Reduce the retry limit in favor of faster tests
 export const MOCK_MAX_RETRIES = 3;
 
+const DEFAULT_RESPONSE_BODY: ResponseBody = {
+  code: 429,
+  error: 'NOT_A_REAL_ERROR',
+  epsThreshold: 0,
+  throttledDevices: {},
+  throttledUsers: {},
+  exceededDailyQuotaDevices: {},
+  exceededDailyQuotaUsers: {},
+  throttledEvents: [],
+};
+
 export class MockThrottledTransport implements Transport {
   private _throttledId: string;
+  private _responseBody: ResponseBody;
+  private _statusCode: number;
+  private _status: Status;
+
   // The number of payloads that got throttled
   public throttleCount: number = 0;
   // The number of payloads that did not get throttled
   public unthrottleCount: number = 0;
-  public constructor(throttledId: string) {
+  public constructor(throttledId: string, response: ResponseBody | null) {
     this._throttledId = throttledId;
+    this._responseBody = response ?? DEFAULT_RESPONSE_BODY;
+    this._statusCode = this._responseBody.code;
+    this._status = Status.fromHttpCode(this._statusCode);
   }
 
   public sendPayload(payload: Payload): Promise<Response> {
     const isMatch = payload.events.some(event => event.user_id === this._throttledId);
     if (isMatch) {
       this.throttleCount += 1;
-      return Promise.resolve({ status: Status.RateLimit, statusCode: 429 });
+      return Promise.resolve({ status: this._status, statusCode: this._statusCode, body: this._responseBody });
     } else {
       this.unthrottleCount += 1;
       return Promise.resolve({ status: Status.Success, statusCode: 200 });

--- a/packages/node/test/mocks/retry.ts
+++ b/packages/node/test/mocks/retry.ts
@@ -1,48 +1,8 @@
 import { RetryHandler } from '../../src/';
-import { Transport, Payload, Status, Response, ResponseBody } from '@amplitude/types';
+import { Transport } from '@amplitude/types';
 
 // Reduce the retry limit in favor of faster tests
 export const MOCK_MAX_RETRIES = 3;
-
-const DEFAULT_RESPONSE_BODY: ResponseBody = {
-  code: 429,
-  error: 'NOT_A_REAL_ERROR',
-  epsThreshold: 0,
-  throttledDevices: {},
-  throttledUsers: {},
-  exceededDailyQuotaDevices: {},
-  exceededDailyQuotaUsers: {},
-  throttledEvents: [],
-};
-
-export class MockThrottledTransport implements Transport {
-  private _failingId: string;
-  private _responseBody: ResponseBody;
-  private _statusCode: number;
-  private _status: Status;
-
-  // The number of payloads that got failed
-  public failCount: number = 0;
-  // The number of payloads that "passed" to the server
-  public passCount: number = 0;
-  public constructor(failingId: string, response: ResponseBody | null) {
-    this._failingId = failingId;
-    this._responseBody = response ?? DEFAULT_RESPONSE_BODY;
-    this._statusCode = this._responseBody.code;
-    this._status = Status.fromHttpCode(this._statusCode);
-  }
-
-  public sendPayload(payload: Payload): Promise<Response> {
-    const isMatch = payload.events.some(event => event.user_id === this._failingId);
-    if (isMatch) {
-      this.failCount += 1;
-      return Promise.resolve({ status: this._status, statusCode: this._statusCode, body: this._responseBody });
-    } else {
-      this.passCount += 1;
-      return Promise.resolve({ status: Status.Success, statusCode: 200 });
-    }
-  }
-}
 
 export class TestRetry extends RetryHandler {
   public retryCount: Map<string, Map<string, number>> = new Map<string, Map<string, number>>();

--- a/packages/node/test/mocks/transport.ts
+++ b/packages/node/test/mocks/transport.ts
@@ -1,7 +1,10 @@
 import { HTTPTransport } from '../../src/transports';
 import { AMPLITUDE_SERVER_URL } from '../../src/constants';
-import { Response } from '@amplitude/types';
+import { Transport, Payload, Status, Response, ResponseBody } from '@amplitude/types';
 
+// A Transport that *extends* the node js transport
+// And only serves to provide convenience setting up HTTPTransport
+// Should be used for testing
 export class TestTransport extends HTTPTransport {
   public constructor() {
     super({
@@ -17,5 +20,48 @@ export class TestTransport extends HTTPTransport {
       api_key: 'NOT_A_REAL_API_KEY',
       events: [],
     });
+  }
+}
+
+const DEFAULT_RESPONSE_BODY: ResponseBody = {
+  code: 429,
+  error: 'NOT_A_REAL_ERROR',
+  epsThreshold: 0,
+  throttledDevices: {},
+  throttledUsers: {},
+  exceededDailyQuotaDevices: {},
+  exceededDailyQuotaUsers: {},
+  throttledEvents: [],
+};
+
+// A mock transport that *implements* the Transposrt interface
+// but does not actually send data. Used to support tests for *other* clases
+// (e.g. retry handler)
+export class MockTransport implements Transport {
+  private _failingId: string;
+  private _responseBody: ResponseBody;
+  private _statusCode: number;
+  private _status: Status;
+
+  // The number of payloads that got failed
+  public failCount: number = 0;
+  // The number of payloads that "passed" to the server
+  public passCount: number = 0;
+  public constructor(failingId: string, response: ResponseBody | null) {
+    this._failingId = failingId;
+    this._responseBody = response ?? DEFAULT_RESPONSE_BODY;
+    this._statusCode = this._responseBody.code;
+    this._status = Status.fromHttpCode(this._statusCode);
+  }
+
+  public sendPayload(payload: Payload): Promise<Response> {
+    const isMatch = payload.events.some(event => event.user_id === this._failingId);
+    if (isMatch) {
+      this.failCount += 1;
+      return Promise.resolve({ status: this._status, statusCode: this._statusCode, body: this._responseBody });
+    } else {
+      this.passCount += 1;
+      return Promise.resolve({ status: Status.Success, statusCode: 200 });
+    }
   }
 }

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -1,4 +1,5 @@
-import { TestRetry, MOCK_MAX_RETRIES, MockThrottledTransport } from './mocks/retry';
+import { TestRetry, MOCK_MAX_RETRIES } from './mocks/retry';
+import { MockTransport } from './mocks/transport';
 import { Event, Status, ResponseBody } from '@amplitude/types';
 import { asyncSleep } from '@amplitude/utils';
 
@@ -14,11 +15,11 @@ const generateEvent = (userId: string): Event => {
 };
 
 describe('retry mechanisms layer', () => {
-  let transport = new MockThrottledTransport(FAILING_USER_ID, null);
+  let transport = new MockTransport(FAILING_USER_ID, null);
   let retry = new TestRetry(transport);
 
   const setupRetry = (body: ResponseBody | null = null) => {
-    transport = new MockThrottledTransport(FAILING_USER_ID, body);
+    transport = new MockTransport(FAILING_USER_ID, body);
     retry = new TestRetry(transport);
   };
 
@@ -111,7 +112,7 @@ describe('retry mechanisms layer', () => {
       };
       setupRetry(body);
 
-      const payload = [generateEvent(FAILING_USER_ID), generateEvent(FAILING_USER_ID)];
+      const payload = [generateEvent(FAILING_USER_ID), generateEvent(PASSING_USER_ID)];
       const response = await retry.sendEventsWithRetry(payload);
       expect(response.status).toBe(Status.Invalid);
       expect(response.statusCode).toBe(400);

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -1,5 +1,5 @@
 import { TestRetry, MOCK_MAX_RETRIES, MockThrottledTransport } from './mocks/retry';
-import { Event, Status } from '@amplitude/types';
+import { Event, Status, ResponseBody } from '@amplitude/types';
 import { asyncSleep } from '@amplitude/utils';
 
 const FAILING_USER_ID = 'data_monster';
@@ -13,26 +13,16 @@ const generateEvent = (userId: string): Event => {
   };
 };
 
-const setupRetry = () => {
-  const transport = new MockThrottledTransport(FAILING_USER_ID);
-  const retry = new TestRetry(transport);
-  return {
-    retry,
-    transport,
-  };
-};
-
 describe('retry mechanisms layer', () => {
-  // A helper that persistently listens to nock and returns the # of
-  // times a user id has been included and hasn't been included.
+  let transport = new MockThrottledTransport(FAILING_USER_ID, null);
+  let retry = new TestRetry(transport);
 
-  let { transport, retry } = setupRetry();
-  beforeEach(() => {
-    // create new instances before each test
-    const newObjects = setupRetry();
-    transport = newObjects.transport;
-    retry = newObjects.retry;
-  });
+  const setupRetry = (body: ResponseBody | null = null) => {
+    transport = new MockThrottledTransport(FAILING_USER_ID, body);
+    retry = new TestRetry(transport);
+  };
+
+  beforeEach(() => setupRetry());
 
   it('should not retry events that pass', async () => {
     const payload = [generateEvent(PASSING_USER_ID)];

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -12,9 +12,9 @@ export type SuccessBody = {
 export type InvalidRequestBody = {
   code: 400;
   error: string;
-  missingField: string;
-  eventsWithInvalidFields: Array<number>;
-  eventsWithMissingFields: Array<number>;
+  missingField: string | null;
+  eventsWithInvalidFields: { [eventField: string]: Array<number> };
+  eventsWithMissingFields: { [eventField: string]: Array<number> };
 };
 
 /** A response body for a request that returned 413 (payload too large). */
@@ -55,9 +55,9 @@ export const mapJSONToResponse = (json: any): ResponseBody | null => {
       return {
         code: 400,
         error: json.error ?? '',
-        missingField: json.missing_field,
-        eventsWithInvalidFields: json.events_with_invalid_fields ?? [],
-        eventsWithMissingFields: json.events_with_missing_fields ?? [],
+        missingField: json.missing_field ?? null,
+        eventsWithInvalidFields: json.events_with_invalid_fields ?? {},
+        eventsWithMissingFields: json.events_with_missing_fields ?? {},
       };
     case 413:
       return {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,3 @@
 export { logger } from './logger';
 export { asyncSleep } from './misc';
+export { collectInvalidEventIndices } from './response';

--- a/packages/utils/src/response.ts
+++ b/packages/utils/src/response.ts
@@ -1,0 +1,33 @@
+import { Response } from '@amplitude/types';
+
+/**
+ * Collects the invalid event indices off a HTTP API v2 response
+ * and returns them in increasing order.
+ *
+ * @param response A Response from sending an event payload
+ * @returns An concatenated array of indices
+ */
+export const collectInvalidEventIndices = (response: Response): Array<number> => {
+  const invalidEventIndices = new Set<number>();
+  if (response.body?.code === 400) {
+    const { eventsWithInvalidFields, eventsWithMissingFields } = response.body ?? {};
+    Object.keys(eventsWithInvalidFields).forEach((field: string) => {
+      const eventIndices = eventsWithInvalidFields[field] ?? [];
+      eventIndices.forEach((index: number) => {
+        if (typeof index === 'number') {
+          invalidEventIndices.add(index);
+        }
+      });
+    });
+    Object.keys(eventsWithMissingFields).forEach((field: string) => {
+      const eventIndices = eventsWithMissingFields[field] ?? [];
+      eventIndices.forEach((index: number) => {
+        if (typeof index === 'number') {
+          invalidEventIndices.add(index);
+        }
+      });
+    });
+  }
+
+  return Array.from(invalidEventIndices).sort();
+};


### PR DESCRIPTION
400's with a single event payload are dropped
400's with the http v2 api response are treated more carefully: 
 - If the payload itself has a missing field, nothing is retried
 - If there are events pointed out as missing/invalid, don't retry those either
 - Fix the 400 body response which was slightly wrong
Tests for all of the above

Better Structuring of the mocks