### PR TITLE
feat(client): Return the Response in both `flush` and `logEvent` #30

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -4,7 +4,7 @@ export { version as SDK_VERSION } from '../package.json';
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
 export const BASE_RETRY_TIMEOUT = 100;
-// The overidable constants of the node SDK
+// The overridable constants of the node SDK
 export const DEFAULT_OPTIONS: Options = {
   serverUrl: AMPLITUDE_SERVER_URL,
   debug: false,

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -1,11 +1,6 @@
-<<<<<<< HEAD
-import { Options, LogLevel } from '@amplitude/types';
+import { Options, LogLevel, Status, Response } from '@amplitude/types';
 // constants related to this instance of the SDK
 export { version as SDK_VERSION } from '../package.json';
-=======
-import { Options, LogLevel, Status, Response } from '@amplitude/types';
-
->>>>>>> c68eb0c... return the response
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
 export const BASE_RETRY_TIMEOUT = 100;

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -1,9 +1,20 @@
+<<<<<<< HEAD
 import { Options, LogLevel } from '@amplitude/types';
 // constants related to this instance of the SDK
 export { version as SDK_VERSION } from '../package.json';
+=======
+import { Options, LogLevel, Status, Response } from '@amplitude/types';
+
+>>>>>>> c68eb0c... return the response
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
 export const BASE_RETRY_TIMEOUT = 100;
+export const SKIPPED_RESPONSE: Response = {
+  status: Status.Skipped,
+  statusCode: 0,
+};
+
+// The overidable constants of the node SDK
 export const DEFAULT_OPTIONS: Options = {
   serverUrl: AMPLITUDE_SERVER_URL,
   debug: false,

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -1,14 +1,9 @@
-import { Options, LogLevel, Status, Response } from '@amplitude/types';
+import { Options, LogLevel } from '@amplitude/types';
 // constants related to this instance of the SDK
 export { version as SDK_VERSION } from '../package.json';
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
 export const BASE_RETRY_TIMEOUT = 100;
-export const SKIPPED_RESPONSE: Response = {
-  status: Status.Skipped,
-  statusCode: 0,
-};
-
 // The overidable constants of the node SDK
 export const DEFAULT_OPTIONS: Options = {
   serverUrl: AMPLITUDE_SERVER_URL,

--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -45,17 +45,17 @@ export class NodeClient implements Client<Options> {
     }
 
     // Check if there's 0 events, flush is not needed.
-    const arrayLength = this._events.length;
-    if (arrayLength === 0) {
+    if (this._events.length === 0) {
       return SKIPPED_RESPONSE;
     }
 
-    // Reset the response listeners and pull them out.
+    // Reset the events + response listeners and pull them out.
     const responseListeners = this._responseListeners;
     this._responseListeners = [];
+    const eventsToSend = this._events;
+    this._events = [];
 
     try {
-      const eventsToSend = this._events.splice(0, arrayLength);
       const response = await this._transportWithRetry.sendEventsWithRetry(eventsToSend);
       responseListeners.forEach(({ resolve }) => resolve(response));
       return response;

--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -1,7 +1,7 @@
-import { Client, Event, Options, Response, RetryClass } from '@amplitude/types';
+import { Client, Event, Options, Response, RetryClass, SKIPPED_RESPONSE } from '@amplitude/types';
 import { logger } from '@amplitude/utils';
 import { RetryHandler } from './retryHandler';
-import { SDK_NAME, SDK_VERSION, DEFAULT_OPTIONS, SKIPPED_RESPONSE } from './constants';
+import { SDK_NAME, SDK_VERSION, DEFAULT_OPTIONS } from './constants';
 
 export class NodeClient implements Client<Options> {
   /** Project Api Key */

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -1,5 +1,6 @@
 import { Event } from './event';
 import { Options } from './options';
+import { Response } from './response';
 
 /**
  * User-Facing Amplitude SDK Client.
@@ -17,10 +18,10 @@ export interface Client<O extends Options = Options> {
    *
    * @param event The event to send to Amplitude.
    */
-  logEvent(event: Event): void;
+  logEvent(event: Event): Promise<Response>;
 
   /**
    * Flush and send all the events which haven't been sent.
    */
-  flush(): void;
+  flush(): Promise<Response>;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,7 +2,7 @@ export { LogLevel } from './logger';
 export { Client } from './client';
 export { Event, Payload } from './event';
 export { Options } from './options';
-export { Response, ResponseBody, mapJSONToResponse, mapHttpMessageToResponse } from './response';
+export { Response, ResponseBody, mapJSONToResponse, mapHttpMessageToResponse, SKIPPED_RESPONSE } from './response';
 export { RetryClass } from './retry';
 export { Status } from './status';
 export { Transport, TransportOptions } from './transport';

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -134,3 +134,11 @@ export type Response =
       status: Exclude<Status, StatusWithResponseBody>;
       statusCode: number;
     };
+
+/** The Response to expect if a request might have been sent but it was skipped
+ *  e.g. no events to flush, user has opted out and nothing should be sent.
+ */
+export const SKIPPED_RESPONSE: Response = {
+  status: Status.Skipped,
+  statusCode: 0,
+};


### PR DESCRIPTION
Adds an ResponseListener that takes in the resolve and rejects from a Promise
Which facilitates always returning a response.
Resolves Issue #12

return the SKIPPED_RESPONSE for Status.Skipped and StatusCode=0, which seems more fitting if nothing happens.