### PR TITLE
hotfix: fix typescript compilation by reverting resolveJsonModule

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -1,6 +1,8 @@
 import { Options, LogLevel } from '@amplitude/types';
 // constants related to this instance of the SDK
-export { version as SDK_VERSION } from '../package.json';
+// TODO(Kelvin): Why did this break typescript compilation?
+// export { version as SDK_VERSION } from '../package.json';
+export const SDK_VERSION = '1.0.1';
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
 export const BASE_RETRY_TIMEOUT = 100;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "types": ["node"],
     "paths": {
       "@amplitude/*": ["*/src"]
-    },
-    "resolveJsonModule": true
+    }
   }
 }


### PR DESCRIPTION
This did not have the intended effect - the dist was failing to compile correctly.