### PR TITLE
feat(node): Add baseRetryTimeout option

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -2,7 +2,6 @@ import { Options, LogLevel } from '@amplitude/types';
 export { version as SDK_VERSION } from '../package.json';
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
-export const BASE_RETRY_TIMEOUT_MS = 100;
 // The overridable constants of the node SDK
 export const DEFAULT_OPTIONS: Options = {
   serverUrl: AMPLITUDE_SERVER_URL,
@@ -11,6 +10,7 @@ export const DEFAULT_OPTIONS: Options = {
   // under 32 MB.
   maxCachedEvents: 16000,
   maxRetries: 10,
+  baseRetryTimeout: 100,
   logLevel: LogLevel.None,
   optOut: false,
   // The client will instantiate the retry/transport classes if not defined

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -18,5 +18,4 @@ export const DEFAULT_OPTIONS: Options = {
   transportClass: null,
   // By default, events flush on the next event loop
   uploadIntervalInSec: 0,
-  retry: ()
 };

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -2,7 +2,7 @@ import { Options, LogLevel } from '@amplitude/types';
 export { version as SDK_VERSION } from '../package.json';
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
-export const BASE_RETRY_TIMEOUT = 100;
+export const BASE_RETRY_TIMEOUT_MS = 100;
 // The overridable constants of the node SDK
 export const DEFAULT_OPTIONS: Options = {
   serverUrl: AMPLITUDE_SERVER_URL,
@@ -18,4 +18,5 @@ export const DEFAULT_OPTIONS: Options = {
   transportClass: null,
   // By default, events flush on the next event loop
   uploadIntervalInSec: 0,
+  retry: ()
 };

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -2,6 +2,7 @@ import { Options, LogLevel } from '@amplitude/types';
 export { version as SDK_VERSION } from '../package.json';
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
+export const BASE_RETRY_TIMEOUT_DEPRECATED = 100;
 // The overridable constants of the node SDK
 export const DEFAULT_OPTIONS: Options = {
   serverUrl: AMPLITUDE_SERVER_URL,

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -9,10 +9,9 @@ export const DEFAULT_OPTIONS: Options = {
   // 2kb is a safe estimate for a medium size event object. This keeps the SDK's memory footprint roughly
   // under 32 MB.
   maxCachedEvents: 16000,
-  maxRetries: 10,
-  baseRetryTimeout: 100,
   logLevel: LogLevel.None,
   optOut: false,
+  retryTimeouts: [100, 100, 200, 200, 400, 400, 800, 800, 1600, 1600, 3200, 3200],
   // The client will instantiate the retry/transport classes if not defined
   retryClass: null,
   transportClass: null,

--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -24,8 +24,8 @@ export class NodeClient implements Client<Options> {
   public constructor(apiKey: string, options: Partial<Options> = {}) {
     this._apiKey = apiKey;
     this._options = Object.assign({}, DEFAULT_OPTIONS, options);
-    this._transportWithRetry = this._options.retryClass ?? this._setupDefaultTransport();
     this._setUpLogging();
+    this._transportWithRetry = this._options.retryClass ?? this._setupDefaultTransport();
   }
 
   /**

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -1,6 +1,6 @@
 import { Event, Options, Transport, TransportOptions, Payload, Status, Response, RetryClass } from '@amplitude/types';
 import { HTTPTransport } from './transports';
-import { DEFAULT_OPTIONS, BASE_RETRY_TIMEOUT } from './constants';
+import { DEFAULT_OPTIONS, BASE_RETRY_TIMEOUT_MS } from './constants';
 import { asyncSleep, collectInvalidEventIndices } from '@amplitude/utils';
 
 interface RetryMetadata {
@@ -263,7 +263,7 @@ export class RetryHandler implements RetryClass {
       } catch {
         if (!isLastTry) {
           // If we haven't hit the retry limit, some Exponential backoff
-          await asyncSleep(BASE_RETRY_TIMEOUT << numRetries); // Sleep for BASE_RETRY_TIMEOUT * 2^(failed tries) ms
+          await asyncSleep(BASE_RETRY_TIMEOUT_MS << numRetries); // Sleep for BASE_RETRY_TIMEOUT_MS * 2^(failed tries) ms
         }
       }
     }

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -1,6 +1,6 @@
 import { Event, Options, Transport, TransportOptions, Payload, Status, Response, RetryClass } from '@amplitude/types';
 import { HTTPTransport } from './transports';
-import { DEFAULT_OPTIONS, BASE_RETRY_TIMEOUT_MS } from './constants';
+import { DEFAULT_OPTIONS } from './constants';
 import { asyncSleep, collectInvalidEventIndices } from '@amplitude/utils';
 
 interface RetryMetadata {
@@ -216,6 +216,7 @@ export class RetryHandler implements RetryClass {
     let eventCount = eventsBuffer.length;
 
     let numRetries = 0;
+    let currentRetryTimeout = this._options.baseRetryTimeout;
     const maxRetries = this._options.maxRetries;
 
     while (numRetries < maxRetries) {
@@ -263,7 +264,8 @@ export class RetryHandler implements RetryClass {
       } catch {
         if (!isLastTry) {
           // If we haven't hit the retry limit, some Exponential backoff
-          await asyncSleep(BASE_RETRY_TIMEOUT_MS << numRetries); // Sleep for BASE_RETRY_TIMEOUT_MS * 2^(failed tries) ms
+          await asyncSleep(currentRetryTimeout); // Sleep for currentRetryTimeout. Time doubles for every failed try
+          currentRetryTimeout *= 2;
         }
       }
     }

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -1,12 +1,25 @@
 import { Event, Options, Transport, TransportOptions, Payload, Status, Response, RetryClass } from '@amplitude/types';
 import { HTTPTransport } from './transports';
-import { DEFAULT_OPTIONS } from './constants';
-import { asyncSleep, collectInvalidEventIndices } from '@amplitude/utils';
+import { DEFAULT_OPTIONS, BASE_RETRY_TIMEOUT_DEPRECATED } from './constants';
+import { asyncSleep, collectInvalidEventIndices, logger } from '@amplitude/utils';
 
 interface RetryMetadata {
   shouldRetry: boolean;
   shouldReduceEventCount: boolean;
   eventIndicesToRemove: number[];
+}
+
+/**
+ * Converts deprecated maxRetries option to retryTimeouts
+ */
+function convertMaxRetries(maxRetries: number): number[] {
+  const retryTimeouts = [];
+  let currentTimeout = BASE_RETRY_TIMEOUT_DEPRECATED;
+  for (let i = 0; i < maxRetries; i++) {
+    retryTimeouts.push(currentTimeout);
+    currentTimeout *= 2;
+  }
+  return retryTimeouts;
 }
 
 export class RetryHandler implements RetryClass {
@@ -15,7 +28,7 @@ export class RetryHandler implements RetryClass {
   // A map of maps to event buffers for failed events
   // The first key is userId (or ''), and second is deviceId (or '')
   private readonly _idToBuffer: Map<string, Map<string, Event[]>> = new Map<string, Map<string, Event[]>>();
-  private readonly _options: Options;
+  protected readonly _options: Options;
   private readonly _transport: Transport;
   private _eventsInRetry = 0;
 
@@ -23,6 +36,13 @@ export class RetryHandler implements RetryClass {
     this._apiKey = apiKey;
     this._options = Object.assign({}, DEFAULT_OPTIONS, options);
     this._transport = this._options.transportClass ?? this._setupDefaultTransport();
+    if (this._options.maxRetries !== undefined) {
+      logger.warn(
+        'DEPRECATED: Please use retryTimeouts. It will be converted to retryTimeouts with exponential wait times (i.e. 100ms -> 200ms -> 400ms -> ...)',
+      );
+      this._options.retryTimeouts = convertMaxRetries(this._options.maxRetries);
+      delete this._options.maxRetries;
+    }
   }
 
   /**

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -56,7 +56,7 @@ export class RetryHandler implements RetryClass {
   }
 
   private _shouldRetryEvents(): boolean {
-    if (typeof this._options.maxRetries !== 'number' || this._options.maxRetries <= 0) {
+    if (this._options.retryTimeouts.length === 0) {
       return false;
     }
 
@@ -215,58 +215,41 @@ export class RetryHandler implements RetryClass {
 
     let eventCount = eventsBuffer.length;
 
-    let numRetries = 0;
-    let currentRetryTimeout = this._options.baseRetryTimeout;
-    const maxRetries = this._options.maxRetries;
+    for (let numRetries = 0; numRetries < this._options.retryTimeouts.length; numRetries++) {
+      const sleepDuration = this._options.retryTimeouts[numRetries];
+      await asyncSleep(sleepDuration);
+      const isLastTry = numRetries === this._options.retryTimeouts.length;
+      const eventsToRetry = eventsBuffer.slice(0, eventCount);
+      const { shouldRetry, shouldReduceEventCount, eventIndicesToRemove } = await this._retryEventsOnce(
+        userId,
+        deviceId,
+        eventsToRetry,
+      );
 
-    while (numRetries < maxRetries) {
-      numRetries += 1;
-      const isLastTry = numRetries === maxRetries;
+      if (eventIndicesToRemove.length > 0) {
+        let numEventsRemoved = 0;
+        // Reverse the indices so that splicing doesn't cause any indexing issues.
+        Array.from(eventIndicesToRemove)
+          .reverse()
+          .forEach(index => {
+            if (index < eventCount) {
+              eventsBuffer.splice(index, 1);
+              numEventsRemoved += 1;
+            }
+          });
 
-      try {
-        // Don't try any new events that came in, to prevent overwhelming the api servers
-        const eventsToRetry = eventsBuffer.slice(0, eventCount);
-        const { shouldRetry, shouldReduceEventCount, eventIndicesToRemove } = await this._retryEventsOnce(
-          userId,
-          deviceId,
-          eventsToRetry,
-        );
-
-        // Collect invalid event indices and remove them.
-        if (eventIndicesToRemove.length > 0) {
-          let numEventsRemoved = 0;
-          // Reverse the indices so that splicing doesn't cause any indexing issues.
-          Array.from(eventIndicesToRemove)
-            .reverse()
-            .forEach(index => {
-              if (index < eventCount) {
-                eventsBuffer.splice(index, 1);
-                numEventsRemoved += 1;
-              }
-            });
-
-          eventCount -= numEventsRemoved;
-          this._eventsInRetry -= eventCount;
-          if (eventCount < 1) {
-            break; // If we managed to remove all the events, break off early.
-          }
+        eventCount -= numEventsRemoved;
+        this._eventsInRetry -= eventCount;
+        if (eventCount < 1) {
+          break; // If we managed to remove all the events, break off early.
         }
+      }
+      if (!shouldRetry) {
+        break; // We ended!
+      }
 
-        if (!shouldRetry) {
-          break; // We ended!
-        }
-
-        if (shouldReduceEventCount && !isLastTry) {
-          eventCount = Math.max(eventCount >> 1, 1);
-        }
-
-        throw new Error(); // If we didn't end, continue to catch block.
-      } catch {
-        if (!isLastTry) {
-          // If we haven't hit the retry limit, some Exponential backoff
-          await asyncSleep(currentRetryTimeout); // Sleep for currentRetryTimeout. Time doubles for every failed try
-          currentRetryTimeout *= 2;
-        }
+      if (shouldReduceEventCount && !isLastTry) {
+        eventCount = Math.max(eventCount >> 1, 1);
       }
     }
 

--- a/packages/node/test/mocks/retry.ts
+++ b/packages/node/test/mocks/retry.ts
@@ -1,15 +1,15 @@
 import { RetryHandler } from '../../src/';
 import { Transport } from '@amplitude/types';
 
-// Reduce the retry limit in favor of faster tests
-export const MOCK_MAX_RETRIES = 3;
+// Reduce default retryTimeouts for faster tests
+export const MOCK_RETRY_TIMEOUTS = [100, 100, 100];
 
 export class TestRetry extends RetryHandler {
   public retryCount: Map<string, Map<string, number>> = new Map<string, Map<string, number>>();
 
   public constructor(transport: Transport) {
     super('NOT_A_REAL_API_KEY', {
-      maxRetries: MOCK_MAX_RETRIES,
+      retryTimeouts: MOCK_RETRY_TIMEOUTS,
       transportClass: transport,
     });
   }

--- a/packages/node/test/mocks/retry.ts
+++ b/packages/node/test/mocks/retry.ts
@@ -1,5 +1,5 @@
 import { RetryHandler } from '../../src/';
-import { Transport } from '@amplitude/types';
+import { Transport, Options } from '@amplitude/types';
 
 // Reduce default retryTimeouts for faster tests
 export const MOCK_RETRY_TIMEOUTS = [100, 100, 100];
@@ -7,10 +7,15 @@ export const MOCK_RETRY_TIMEOUTS = [100, 100, 100];
 export class TestRetry extends RetryHandler {
   public retryCount: Map<string, Map<string, number>> = new Map<string, Map<string, number>>();
 
-  public constructor(transport: Transport) {
+  public constructor(transport: Transport, options?: Partial<Options>) {
     super('NOT_A_REAL_API_KEY', {
       retryTimeouts: MOCK_RETRY_TIMEOUTS,
       transportClass: transport,
+      ...options,
     });
+  }
+
+  public getOptions(): Partial<Options> {
+    return { ...this._options };
   }
 }

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -1,4 +1,4 @@
-import { TestRetry, MOCK_MAX_RETRIES } from './mocks/retry';
+import { TestRetry, MOCK_RETRY_TIMEOUTS } from './mocks/retry';
 import { MockTransport } from './mocks/transport';
 import { Event, Status, Response, RetryClass } from '@amplitude/types';
 import { asyncSleep } from '@amplitude/utils';
@@ -44,8 +44,8 @@ describe('retry mechanisms layer', () => {
 
     expect(response.status).toBe(Status.RateLimit);
     expect(response.statusCode).toBe(429);
-    // One response goes out matching the initial send, MOCK_MAX_RETRIES for the retry layer
-    expect(transport.failCount).toBe(MOCK_MAX_RETRIES + 1);
+    // One response goes out matching the initial send, MOCK_RETRY_TIMEOUTS for the retry layer
+    expect(transport.failCount).toBe(MOCK_RETRY_TIMEOUTS.length + 1);
   });
 
   it('will not throttle user ids that are not throttled', async () => {
@@ -60,7 +60,7 @@ describe('retry mechanisms layer', () => {
     expect(response.status).toBe(Status.RateLimit);
     expect(response.statusCode).toBe(429);
     // One response goes out matching the initial send
-    expect(transport.failCount).toBe(MOCK_MAX_RETRIES + 1);
+    expect(transport.failCount).toBe(MOCK_RETRY_TIMEOUTS.length + 1);
     // One response goes out for the passing event not getting 'throttled'
     expect(transport.passCount).toBe(1);
   });

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -70,10 +70,6 @@ describe('retry mechanisms layer', () => {
 
   it('will convert deprecated options.maxRetries to options.retryTimeouts', async () => {
     const { retry } = generateRetryHandler(null, { maxRetries: 3 });
-    const payload = [generateEvent(FAILING_USER_ID), generateEvent(PASSING_USER_ID)];
-    await retry.sendEventsWithRetry(payload);
-    // Sleep and wait for retries to end
-    await asyncSleep(1000);
     expect(retry.getOptions().maxRetries).toBeUndefined();
     expect(retry.getOptions().retryTimeouts).toEqual([100, 200, 400]);
   });

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -25,8 +25,15 @@ export interface Options {
   /** The maximum events in the buffer */
   maxCachedEvents: number;
 
-  /** The maximum number of times a server will attempt to retry  */
+  /** The maximum number of times a server will attempt to retry sending events after failiure*/
   maxRetries: number;
+
+  /**
+   * Base milliseconds failed events sending should wait until retrying.
+   * Each subsequent failed event sending will current the wait time by 2.
+   * (Example: 100ms -> 200ms -> 400ms -> 800ms -> ...)
+   */
+  baseRetryTimeout: number;
 
   /**
    * Whether you opt out from sending events.

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -25,7 +25,7 @@ export interface Options {
   /** The maximum events in the buffer */
   maxCachedEvents: number;
 
-  /** The maximum number of times a server will attempt to retry sending events after failiure*/
+  /** The maximum number of times a server will attempt to retry sending events after failiure */
   maxRetries: number;
 
   /**

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -26,7 +26,12 @@ export interface Options {
   maxCachedEvents: number;
 
   /**
-   *
+   * The maximum number of times a server will attempt to retry
+   * @deprecated Please use retryTimeouts. It will be converted to retryTimeouts with exponential wait times (e.g. 100ms -> 200ms -> 400ms -> ...)'
+   */
+  maxRetries?: number;
+
+  /**
    * Determines # of retries for sending failed events and how long each retry to wait for (ms)
    * An empty array means no retries
    */

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -25,15 +25,12 @@ export interface Options {
   /** The maximum events in the buffer */
   maxCachedEvents: number;
 
-  /** The maximum number of times a server will attempt to retry sending events after failiure */
-  maxRetries: number;
-
   /**
-   * Base milliseconds failed events sending should wait until retrying.
-   * Each subsequent failed event sending will current the wait time by 2.
-   * (Example: 100ms -> 200ms -> 400ms -> 800ms -> ...)
+   *
+   * Determines # of retries for sending failed events and how long each retry to wait for (ms)
+   * An empty array means no retries
    */
-  baseRetryTimeout: number;
+  retryTimeouts: number[];
 
   /**
    * Whether you opt out from sending events.


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
- Adds `retryTimeouts` to options
  - Deprecates `BASE_RETRY_TIMEOUT` and `maxRetries`
    - Adds tests for deprecation
  - Adjusts `RetryHandler` logic to handle array rather than number
- Replace bit shifting with [`currentRetryTimeout`](https://github.com/amplitude/Amplitude-Node/compare/improve-sleep-retry#diff-f993d036e43711879797431141303499ab67f15598b27a926ca91c6fbfd1b010R203)
- Exposes `options` property of `RetryHandler` so that it can be read from tests


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
