### PR TITLE
fix: Second logEvent does not schedule a flush

### DIFF
--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -42,6 +42,7 @@ export class NodeClient implements Client<Options> {
     // Clear the timeout
     if (this._flushTimer !== null) {
       clearTimeout(this._flushTimer);
+      this._flushTimer = null;
     }
 
     // Check if there's 0 events, flush is not needed.


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Currently, a second logEvent does not trigger a flush in the next event loop.
This is because the null check from L87 fails.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
