### PR TITLE
fix(ci): prepare builds before actually publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "fix": "lerna run --stream --concurrency 1 fix",
     "link:yarn": "lerna run --stream --concurrency 1 link:yarn",
     "lint": "lerna run --stream --concurrency 1 lint",
+    "prepare": "yarn build",
     "test": "lerna run test --stream --concurrency 9999"
   },
   "workspaces": [


### PR DESCRIPTION
### Summary

Run yarn build (lerna's build) before packing and publishing npm publishing, saving myself the embarrassment of publishing the wrong packages and also makes sure the builds succeed.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
