### PR TITLE
chore: change eslint-config-typescript version for lerna publish

### DIFF
--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplitude/eslint-config-typescript",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "ESLint config for Amplitude Typescript projects",
   "keywords": [
     "eslint",


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
- `lerna publish` won't work unless this version is bumped, I believe this is because it wasn't tracked in the 1.0.4 release. See current state: 

![image](https://user-images.githubusercontent.com/15751908/98179080-d3b81280-1eb2-11eb-9df4-c88adf46c46b.png)
 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
