### PR TITLE
chore(lint): Configure all the workspaces to use eslint configurations

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -8,8 +8,6 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
-    'prettier',
-    'prettier/@typescript-eslint',
     'standard-with-typescript',
   ],
   globals: {

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -8,6 +8,8 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'prettier',
+    'prettier/@typescript-eslint',
     'standard-with-typescript',
   ],
   globals: {

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "main": "index.js",
   "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@amplitude/eslint-config-typescript": "^1.0.4",
     "@amplitude/types": "^1.0.4",
     "@amplitude/utils": "^1.0.4"
   },

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -4,9 +4,9 @@ import { Identity, IdentityListener } from '@amplitude/types';
 export class DefaultIdentity implements Identity {
   private _deviceId: string | null = null;
   private _userId: string | null = null;
-  private _identityListeners: Array<IdentityListener> = [];
+  private readonly _identityListeners: IdentityListener[] = [];
 
-  public static generateDefaultId = () => {
+  public static generateDefaultId = (): string => {
     return generateBase36Id();
   };
 
@@ -19,7 +19,7 @@ export class DefaultIdentity implements Identity {
    * @param   {string} deviceId An optional parameter to set the device ID to use.
    * @returns {string}          The device ID that will be used for this instance going forward.
    */
-  public initializeDeviceId(deviceId: string = ''): string {
+  public initializeDeviceId(deviceId = ''): string {
     // Only try to set the device ID if the deviceID is not already set.
     if (this._deviceId !== null) {
       logger.warn('Cannot set device ID twice for same identity. Skipping operation.');
@@ -27,7 +27,7 @@ export class DefaultIdentity implements Identity {
       return this._deviceId;
     }
 
-    let deviceIdToUse: string = '';
+    let deviceIdToUse = '';
 
     if (typeof deviceId === 'string' && deviceId.length > 0) {
       deviceIdToUse = deviceId;
@@ -80,17 +80,17 @@ export class DefaultIdentity implements Identity {
       // initializeDeviceID re-alert this function
       this.initializeDeviceId();
     } else {
-      for (let listener of this._identityListeners) {
+      for (const listener of this._identityListeners) {
         listener(this._deviceId, this._userId);
       }
     }
   }
 
-  public addIdentityListener(...listeners: Array<IdentityListener>): void {
+  public addIdentityListener(...listeners: IdentityListener[]): void {
     this._identityListeners.push(...listeners);
   }
 
-  public getIdentityListeners(): Array<IdentityListener> {
+  public getIdentityListeners(): IdentityListener[] {
     // Return a copy of the listeners
     return Array.from(this._identityListeners);
   }

--- a/packages/identity/src/identityManager.ts
+++ b/packages/identity/src/identityManager.ts
@@ -4,14 +4,14 @@ import { Identity, IdentityListener, DEFAULT_IDENTITY_INSTANCE } from '@amplitud
 import { DefaultIdentity } from './identity';
 
 class IdentityManager {
-  private _instanceMap: Map<string, Identity> = new Map<string, Identity>();
+  private readonly _instanceMap: Map<string, Identity> = new Map<string, Identity>();
 
   public getInstance(
     instanceName: string = DEFAULT_IDENTITY_INSTANCE,
     optionalFallbackIdentity: Identity | null = null,
   ): Identity {
     let identity = this._instanceMap.get(instanceName);
-    if (identity == undefined) {
+    if (identity === undefined) {
       identity = optionalFallbackIdentity !== null ? optionalFallbackIdentity : new DefaultIdentity();
       this._instanceMap.set(instanceName, identity);
     }
@@ -29,8 +29,8 @@ class IdentityManager {
     optionalNewIdentity: Identity | null = null,
   ): void {
     const oldIdentity = this._instanceMap.get(instanceName);
-    const oldListeners: Array<IdentityListener> = oldIdentity?.getIdentityListeners() || [];
-    if (!oldIdentity) {
+    const oldListeners: IdentityListener[] = oldIdentity?.getIdentityListeners() ?? [];
+    if (oldIdentity === undefined) {
       logger.warn(`Did not find a identity to reset for ${instanceName}`);
     } else {
       this._instanceMap.delete(instanceName);
@@ -48,7 +48,7 @@ class IdentityManager {
 
     if (oldListeners.length > 0) {
       // Actively call the old listeners for the new identity
-      for (let listener of oldListeners) {
+      for (const listener of oldListeners) {
         listener(newIdentity.getDeviceId(), newIdentity.getUserId());
       }
 
@@ -61,7 +61,7 @@ class IdentityManager {
 const globalNamespace = getGlobalAmplitudeNamespace();
 
 let identityManager: IdentityManager = globalNamespace.identityManager as IdentityManager;
-if (!identityManager) {
+if (identityManager === undefined) {
   identityManager = new IdentityManager();
   globalNamespace.identityManager = identityManager;
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@amplitude/eslint-config-typescript": "^1.0.4",
     "@amplitude/types": "^1.0.4",
     "@amplitude/utils": "^1.0.4",
     "tslib": "^1.9.3"

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -208,7 +208,7 @@ export class RetryHandler implements RetryClass {
 
   private async _retryEventsOnLoop(userId: string, deviceId: string): Promise<void> {
     const eventsBuffer = this._getRetryBuffer(userId, deviceId);
-    if (eventsBuffer === null || eventsBuffer.length > 0) {
+    if (eventsBuffer === null || eventsBuffer.length === 0) {
       this._cleanUpBuffer(userId, deviceId);
       return;
     }

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -8,21 +8,21 @@ export class RetryHandler implements RetryClass {
 
   // A map of maps to event buffers for failed events
   // The first key is userId (or ''), and second is deviceId (or '')
-  private _idToBuffer: Map<string, Map<string, Array<Event>>> = new Map<string, Map<string, Array<Event>>>();
-  private _options: Options;
-  private _transport: Transport;
-  private _eventsInRetry: number = 0;
+  private readonly _idToBuffer: Map<string, Map<string, Event[]>> = new Map<string, Map<string, Event[]>>();
+  private readonly _options: Options;
+  private readonly _transport: Transport;
+  private _eventsInRetry = 0;
 
   public constructor(apiKey: string, options: Partial<Options>) {
     this._apiKey = apiKey;
     this._options = Object.assign({}, DEFAULT_OPTIONS, options);
-    this._transport = this._options.transportClass || this._setupDefaultTransport();
+    this._transport = this._options.transportClass ?? this._setupDefaultTransport();
   }
 
   /**
    * @inheritDoc
    */
-  public async sendEventsWithRetry(events: ReadonlyArray<Event>): Promise<Response> {
+  public async sendEventsWithRetry(events: readonly Event[]): Promise<Response> {
     let response: Response = { status: Status.Unknown, statusCode: 0 };
     const eventsToSend = this._pruneEvents(events);
     try {
@@ -34,9 +34,9 @@ export class RetryHandler implements RetryClass {
       if (this._shouldRetryEvents()) {
         this._onEventsError(events, response);
       }
-    } finally {
-      return response;
     }
+
+    return response;
   }
 
   private _setupDefaultTransport(): Transport {
@@ -60,13 +60,13 @@ export class RetryHandler implements RetryClass {
 
   // Sends events with ids currently in active retry buffers straight
   // to the retry buffer they should be in
-  private _pruneEvents(events: ReadonlyArray<Event>): Array<Event> {
-    const prunedEvents: Array<Event> = [];
+  private _pruneEvents(events: readonly Event[]): Event[] {
+    const prunedEvents: Event[] = [];
     events.forEach(event => {
       const { user_id: userId = '', device_id: deviceId = '' } = event;
-      if (userId || deviceId) {
+      if (userId.length > 0 || deviceId.length > 0) {
         const retryBuffer = this._getRetryBuffer(userId, deviceId);
-        if (retryBuffer?.length) {
+        if (retryBuffer !== null) {
           retryBuffer.push(event);
           this._eventsInRetry++;
         } else {
@@ -78,31 +78,31 @@ export class RetryHandler implements RetryClass {
     return prunedEvents;
   }
 
-  private _getPayload(events: ReadonlyArray<Event>): Payload {
+  private _getPayload(events: readonly Event[]): Payload {
     return {
       api_key: this._apiKey,
       events,
     };
   }
 
-  private _getRetryBuffer(userId: string, deviceId: string): Array<Event> | null {
+  private _getRetryBuffer(userId: string, deviceId: string): Event[] | null {
     const deviceToBufferMap = this._idToBuffer.get(userId);
-    if (!deviceToBufferMap) {
+    if (deviceToBufferMap === undefined) {
       return null;
     }
 
-    return deviceToBufferMap.get(deviceId) || null;
+    return deviceToBufferMap.get(deviceId) ?? null;
   }
 
   // cleans up the id to buffer map if the job is done
   private _cleanUpBuffer(userId: string, deviceId: string): void {
     const deviceToBufferMap = this._idToBuffer.get(userId);
-    if (!deviceToBufferMap) {
+    if (deviceToBufferMap === undefined) {
       return;
     }
 
     const eventsToRetry = deviceToBufferMap.get(deviceId);
-    if (!eventsToRetry?.length) {
+    if (eventsToRetry !== undefined && eventsToRetry.length === 0) {
       deviceToBufferMap.delete(deviceId);
     }
 
@@ -111,16 +111,16 @@ export class RetryHandler implements RetryClass {
     }
   }
 
-  private _onEventsError(events: ReadonlyArray<Event>, response: Response): void {
-    let eventsToRetry: ReadonlyArray<Event> = events;
+  private _onEventsError(events: readonly Event[], response: Response): void {
+    let eventsToRetry: readonly Event[] = events;
     // See if there are any events we can immediately throw out
-    if (response.status === Status.RateLimit && response.body) {
+    if (response.status === Status.RateLimit && response.body !== undefined) {
       const { exceededDailyQuotaUsers, exceededDailyQuotaDevices } = response.body;
       eventsToRetry = events.filter(({ user_id: userId, device_id: deviceId }) => {
         return !(userId && exceededDailyQuotaUsers[userId]) && !(deviceId && exceededDailyQuotaDevices[deviceId]);
       });
     } else if (response.status === Status.Invalid) {
-      if (response.body?.missingField || events.length === 1) {
+      if (typeof response.body?.missingField === 'string' || events.length === 1) {
         // Return early if there's an issue with the entire payload
         // or if there's only one event and its invalid
         return;
@@ -139,7 +139,7 @@ export class RetryHandler implements RetryClass {
       if (userId || deviceId) {
         let deviceToBufferMap = this._idToBuffer.get(userId);
         if (!deviceToBufferMap) {
-          deviceToBufferMap = new Map<string, Array<Event>>();
+          deviceToBufferMap = new Map<string, Event[]>();
           this._idToBuffer.set(userId, deviceToBufferMap);
         }
 
@@ -148,7 +148,10 @@ export class RetryHandler implements RetryClass {
           retryBuffer = [];
           deviceToBufferMap.set(deviceId, retryBuffer);
           // In the next event loop, start retrying these events
-          setTimeout(() => this._retryEventsOnLoop(userId, deviceId), 0);
+          setTimeout(() => {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this._retryEventsOnLoop(userId, deviceId);
+          }, 0);
         }
 
         this._eventsInRetry++;
@@ -157,12 +160,12 @@ export class RetryHandler implements RetryClass {
     });
   }
 
-  private async _retryEventsOnce(userId: string, deviceId: string, eventsToRetry: ReadonlyArray<Event>) {
+  private async _retryEventsOnce(userId: string, deviceId: string, eventsToRetry: readonly Event[]) {
     const response = await this._transport.sendPayload(this._getPayload(eventsToRetry));
 
     let shouldRetry = true;
     let shouldReduceEventCount = false;
-    let eventIndicesToRemove: Array<number> = [];
+    let eventIndicesToRemove: number[] = [];
 
     if (response.status === Status.RateLimit) {
       // RateLimit: See if we hit the daily quota
@@ -192,7 +195,7 @@ export class RetryHandler implements RetryClass {
 
   private async _retryEventsOnLoop(userId: string, deviceId: string): Promise<void> {
     const eventsBuffer = this._getRetryBuffer(userId, deviceId);
-    if (!eventsBuffer?.length) {
+    if (eventsBuffer === null || eventsBuffer.length > 0) {
       this._cleanUpBuffer(userId, deviceId);
       return;
     }
@@ -260,6 +263,9 @@ export class RetryHandler implements RetryClass {
     // if more events came in during this time,
     // retry them on a new loop
     // otherwise, this call will immediately return on the next event loop.
-    setTimeout(() => this._retryEventsOnLoop(userId, deviceId), 0);
+    setTimeout(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this._retryEventsOnLoop(userId, deviceId);
+    }, 0);
   }
 }

--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -21,10 +21,10 @@ export interface HTTPRequest {
   ): http.ClientRequest;
 }
 
-type RequestQueueObject = {
+interface RequestQueueObject {
   callback: () => void;
   cancellingTimeout: NodeJS.Timeout | null;
-};
+}
 
 // Automatially cancel requests that have been waiting for 10+ s
 const REQUEST_CANCEL_TIMEOUT = 10 * 1000;
@@ -34,8 +34,8 @@ export class HTTPTransport implements Transport {
   /** The Agent used for corresponding transport */
   public module: HTTPRequest;
 
-  protected _uploadInProgress: boolean = false;
-  protected _requestQueue: Array<RequestQueueObject> = [];
+  protected _uploadInProgress = false;
+  protected _requestQueue: RequestQueueObject[] = [];
 
   /** Create instance and set this.dsn */
   public constructor(public options: TransportOptions) {
@@ -52,11 +52,11 @@ export class HTTPTransport implements Transport {
    * @inheritDoc
    */
   public async sendPayload(payload: Payload): Promise<Response> {
-    const call = () => this._sendWithModule(payload);
+    const call = async (): Promise<Response> => await this._sendWithModule(payload);
 
     // Queue up the call to send the payload.
     // Wait 10 seconds for each request in queue before removing it
-    return this._awaitUploadFinish(call, REQUEST_CANCEL_TIMEOUT);
+    return await this._awaitUploadFinish(call, REQUEST_CANCEL_TIMEOUT);
   }
 
   /** Returns a build request option object used by request */
@@ -81,9 +81,9 @@ export class HTTPTransport implements Transport {
   // Awaits the finish of all requests that have been queued up before it
   // And will expire itself (reject the promise) after waiting limit ms
   // or never expire, if limit is not set
-  private _awaitUploadFinish(callback: () => Promise<Response>, limitInMs: number = 0): Promise<Response> {
-    return new Promise((resolve, reject) => {
-      const queueCallback = () => {
+  private async _awaitUploadFinish(callback: () => Promise<Response>, limitInMs = 0): Promise<Response> {
+    return await new Promise((resolve, reject) => {
+      const queueCallback = (): void => {
         this._uploadInProgress = true;
         try {
           resolve(callback());
@@ -117,7 +117,7 @@ export class HTTPTransport implements Transport {
             this._requestQueue.splice(callBackIndex, 1);
           }
 
-          reject();
+          reject(new Error(''));
         }, limitInMs);
       }
     });
@@ -127,7 +127,7 @@ export class HTTPTransport implements Transport {
   private _notifyUploadFinish(): void {
     this._uploadInProgress = false;
     const oldestRequest = this._requestQueue.shift();
-    if (oldestRequest) {
+    if (oldestRequest !== undefined) {
       if (oldestRequest.cancellingTimeout !== null) {
         // Clear the timeout where we try to remove the callback and reject the promise.
         clearTimeout(oldestRequest.cancellingTimeout);
@@ -138,23 +138,25 @@ export class HTTPTransport implements Transport {
 
   /** JSDoc */
   protected async _sendWithModule(payload: Payload): Promise<Response> {
-    return new Promise<Response>((resolve, reject) => {
+    return await new Promise<Response>((resolve, reject) => {
       const req = this.module.request(this._getRequestOptions(), (res: http.IncomingMessage) => {
         res.setEncoding('utf8');
         let rawData = '';
         // Collect the body data from the response
-        res.on('data', chunk => {
+        res.on('data', (chunk: string) => {
           rawData += chunk;
         });
         // On completion, parse the data and resolve.
         res.on('end', () => {
-          if (res.complete && rawData) {
+          if (res.complete && rawData.length > 0) {
             try {
               const responseWithBody = mapJSONToResponse(JSON.parse(rawData));
               if (responseWithBody !== null) {
                 return resolve(responseWithBody);
               }
-            } catch {}
+            } catch {
+              // pass
+            }
           }
 
           // Fallback: get the response object directly from the incoming message

--- a/packages/node/test/mocks/transport.ts
+++ b/packages/node/test/mocks/transport.ts
@@ -15,8 +15,8 @@ export class TestTransport extends HTTPTransport {
     });
   }
 
-  public sendDummyPayload(): Promise<Response> {
-    return this.sendPayload({
+  public async sendDummyPayload(): Promise<Response> {
+    return await this.sendPayload({
       api_key: 'NOT_A_REAL_API_KEY',
       events: [],
     });
@@ -41,18 +41,18 @@ const DEFAULT_RESPONSE_BODY: Response = {
 // but does not actually send data. Used to support tests for *other* clases
 // (e.g. retry handler)
 export class MockTransport implements Transport {
-  private _failingId: string;
-  private _response: Response;
+  private readonly _failingId: string;
+  private readonly _response: Response;
   // The number of payloads that got failed
-  public failCount: number = 0;
+  public failCount = 0;
   // The number of payloads that "passed" to the server
-  public passCount: number = 0;
+  public passCount = 0;
   public constructor(failingId: string, response: Response | null) {
     this._failingId = failingId;
     this._response = response ?? DEFAULT_RESPONSE_BODY;
   }
 
-  public sendPayload(payload: Payload): Promise<Response> {
+  public async sendPayload(payload: Payload): Promise<Response> {
     const isMatch = payload.events.some(event => event.user_id === this._failingId);
     if (isMatch) {
       this.failCount += 1;

--- a/packages/node/test/transport.test.ts
+++ b/packages/node/test/transport.test.ts
@@ -3,7 +3,7 @@ import { AMPLITUDE_SERVER_URL } from '../src/constants';
 import { Status } from '@amplitude/types';
 import * as nock from 'nock';
 
-const anyMatch = () => true;
+const anyMatch = (): boolean => true;
 describe('http transport layer', () => {
   // After each test, remove any remaining mocks.
   afterEach(() => nock.cleanAll());

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -39,5 +39,8 @@
     "link:yarn": "yarn link",
     "test": "echo 'Types directory has no logic and therefore no tests, skipping tests'"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "@amplitude/eslint-config-typescript": "^1.0.4"
+  }
 }

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -43,5 +43,5 @@ export interface Event {
  */
 export interface Payload {
   api_key: string;
-  events: ReadonlyArray<Event>;
+  events: readonly Event[];
 }

--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -20,6 +20,6 @@ export interface Identity {
   /** Get the User ID of the identity, if it exists */
   getUserId(): string | null;
 
-  addIdentityListener(...listeners: Array<IdentityListener>): any;
-  getIdentityListeners(): Array<IdentityListener>;
+  addIdentityListener(...listeners: IdentityListener[]): any;
+  getIdentityListeners(): IdentityListener[];
 }

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -1,35 +1,35 @@
 import { Status } from './status';
 
 /** A response body for a request that returned 200 (successful). */
-export type SuccessBody = {
+export interface SuccessBody {
   eventsIngested: number;
   payloadSizeBytes: number;
   serverUploadTime: number;
-};
+}
 
 /** A response body for a request that returned 413 (invalid request). */
-export type InvalidRequestBody = {
+export interface InvalidRequestBody {
   error: string;
   missingField: string | null;
-  eventsWithInvalidFields: { [eventField: string]: Array<number> };
-  eventsWithMissingFields: { [eventField: string]: Array<number> };
-};
+  eventsWithInvalidFields: { [eventField: string]: number[] };
+  eventsWithMissingFields: { [eventField: string]: number[] };
+}
 
 /** A response body for a request that returned 413 (payload too large). */
-export type PayloadTooLargeBody = {
+export interface PayloadTooLargeBody {
   error: string;
-};
+}
 
 /** A response body for a request that returned 429 (rate limit). */
-export type RateLimitBody = {
+export interface RateLimitBody {
   error: string;
   epsThreshold: number;
   throttledDevices: { [deviceId: string]: number };
   throttledUsers: { [userId: string]: number };
   exceededDailyQuotaDevices: { [deviceId: string]: number };
   exceededDailyQuotaUsers: { [userId: string]: number };
-  throttledEvents: Array<number>;
-};
+  throttledEvents: number[];
+}
 
 export type StatusWithResponseBody = Status.Invalid | Status.PayloadTooLarge | Status.RateLimit | Status.Success;
 
@@ -39,29 +39,29 @@ export type ResponseBody = SuccessBody | InvalidRequestBody | PayloadTooLargeBod
 /** JSDoc */
 export type Response =
   | {
-      status: Status.Success;
-      statusCode: number;
-      body?: SuccessBody;
-    }
+    status: Status.Success;
+    statusCode: number;
+    body?: SuccessBody;
+  }
   | {
-      status: Status.Invalid;
-      statusCode: number;
-      body?: InvalidRequestBody;
-    }
+    status: Status.Invalid;
+    statusCode: number;
+    body?: InvalidRequestBody;
+  }
   | {
-      status: Status.PayloadTooLarge;
-      statusCode: number;
-      body?: PayloadTooLargeBody;
-    }
+    status: Status.PayloadTooLarge;
+    statusCode: number;
+    body?: PayloadTooLargeBody;
+  }
   | {
-      status: Status.RateLimit;
-      statusCode: number;
-      body?: RateLimitBody;
-    }
+    status: Status.RateLimit;
+    statusCode: number;
+    body?: RateLimitBody;
+  }
   | {
-      status: Exclude<Status, StatusWithResponseBody>;
-      statusCode: number;
-    };
+    status: Exclude<Status, StatusWithResponseBody>;
+    statusCode: number;
+  };
 
 /** The Response to expect if a request might have been sent but it was skipped
  *  e.g. no events to flush, user has opted out and nothing should be sent.

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -39,29 +39,29 @@ export type ResponseBody = SuccessBody | InvalidRequestBody | PayloadTooLargeBod
 /** JSDoc */
 export type Response =
   | {
-    status: Status.Success;
-    statusCode: number;
-    body?: SuccessBody;
-  }
+      status: Status.Success;
+      statusCode: number;
+      body?: SuccessBody;
+    }
   | {
-    status: Status.Invalid;
-    statusCode: number;
-    body?: InvalidRequestBody;
-  }
+      status: Status.Invalid;
+      statusCode: number;
+      body?: InvalidRequestBody;
+    }
   | {
-    status: Status.PayloadTooLarge;
-    statusCode: number;
-    body?: PayloadTooLargeBody;
-  }
+      status: Status.PayloadTooLarge;
+      statusCode: number;
+      body?: PayloadTooLargeBody;
+    }
   | {
-    status: Status.RateLimit;
-    statusCode: number;
-    body?: RateLimitBody;
-  }
+      status: Status.RateLimit;
+      statusCode: number;
+      body?: RateLimitBody;
+    }
   | {
-    status: Exclude<Status, StatusWithResponseBody>;
-    statusCode: number;
-  };
+      status: Exclude<Status, StatusWithResponseBody>;
+      statusCode: number;
+    };
 
 /** The Response to expect if a request might have been sent but it was skipped
  *  e.g. no events to flush, user has opted out and nothing should be sent.

--- a/packages/types/src/retry.ts
+++ b/packages/types/src/retry.ts
@@ -8,5 +8,5 @@ export interface RetryClass {
    *
    * @param events The events that should be sent to Amplitude.
    */
-  sendEventsWithRetry(events: ReadonlyArray<Event>): Promise<Response>;
+  sendEventsWithRetry(events: readonly Event[]): Promise<Response>;
 }

--- a/packages/types/src/status.ts
+++ b/packages/types/src/status.ts
@@ -15,36 +15,3 @@ export enum Status {
   /** A server-side error ocurred during submission. */
   Failed = 'failed',
 }
-// tslint:disable:completed-docs
-// tslint:disable:no-unnecessary-qualifier no-namespace
-export namespace Status {
-  /**
-   * Converts a HTTP status code into a {@link Status}.
-   *
-   * @param code The HTTP response status code.
-   * @returns The send status or {@link Status.Unknown}.
-   */
-  export function fromHttpCode(code: number): Status {
-    if (code >= 200 && code < 300) {
-      return Status.Success;
-    }
-
-    if (code === 429) {
-      return Status.RateLimit;
-    }
-
-    if (code === 413) {
-      return Status.PayloadTooLarge;
-    }
-
-    if (code >= 400 && code < 500) {
-      return Status.Invalid;
-    }
-
-    if (code >= 500) {
-      return Status.Failed;
-    }
-
-    return Status.Unknown;
-  }
-}

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -11,6 +11,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@amplitude/eslint-config-typescript": "^1.0.4",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "eslint-config-standard": "^14.1.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@amplitude/eslint-config-typescript": "^1.0.4",
     "@amplitude/types": "^1.0.4"
   },
   "devDependencies": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,3 +2,4 @@ export { generateBase36Id, DEVICE_ID_LENGTH } from './base36';
 export { logger } from './logger';
 export { asyncSleep, getGlobalAmplitudeNamespace, isBrowserEnv, isNodeEnv, prototypeJsFix } from './misc';
 export { collectInvalidEventIndices, mapHttpMessageToResponse, mapJSONToResponse } from './response';
+export { mapHttpCodeToStatus } from './status';

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -53,6 +53,10 @@ class Logger {
 }
 
 // Ensure we only have a single logger instance, even if multiple versions of @amplitude/utils are being used
-const logger = (globalNamespace.logger as Logger) || (globalNamespace.logger = new Logger());
+let logger: Logger = globalNamespace.logger as Logger;
+if (logger === undefined) {
+  logger = new Logger();
+  globalNamespace.logger = logger;
+}
 
 export { logger };

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -24,18 +24,22 @@ const fallbackGlobalObject = {};
  * @returns Global scope object
  */
 export const getGlobalObject = (): any => {
-  return isNodeEnv()
-    ? global
-    : typeof window !== 'undefined'
-    ? window
-    : typeof self !== 'undefined'
-    ? self
-    : fallbackGlobalObject;
+  if (isNodeEnv()) {
+    return global;
+  } else if (typeof window !== 'undefined') {
+    return window;
+  } else if (typeof self !== 'undefined') {
+    return self;
+  } else {
+    return fallbackGlobalObject;
+  }
 };
 
 export const getGlobalAmplitudeNamespace = (): any => {
   const global = getGlobalObject();
-  global.__AMPLITUDE__ = global.__AMPLITUDE__ || {};
+  if (global.__AMPLITUDE__ === undefined) {
+    global.__AMPLITUDE__ = {};
+  }
 
   return global.__AMPLITUDE__;
 };
@@ -46,8 +50,8 @@ export const getGlobalAmplitudeNamespace = (): any => {
  *
  * @param milliseconds The number of milliseconds to wait for
  */
-export const asyncSleep = (milliseconds: number): Promise<void> => {
-  return new Promise(resolve => setTimeout(resolve, milliseconds));
+export const asyncSleep = async (milliseconds: number): Promise<void> => {
+  return await new Promise(resolve => setTimeout(resolve, milliseconds));
 };
 
 /**
@@ -58,7 +62,7 @@ export const asyncSleep = (milliseconds: number): Promise<void> => {
 export const prototypeJsFix = (): boolean => {
   // Augment and cast built-ins to represent Prototype.js injection
   interface Window {
-    Prototype?: Object;
+    Prototype?: Record<string, any>;
   }
   interface ArrayConstructor {
     prototype?: { toJSON?: Function };

--- a/packages/utils/src/response.ts
+++ b/packages/utils/src/response.ts
@@ -8,9 +8,9 @@ import { IncomingMessage } from 'http';
  * @param response A Response from sending an event payload
  * @returns An concatenated array of indices
  */
-export const collectInvalidEventIndices = (response: Response): Array<number> => {
+export const collectInvalidEventIndices = (response: Response): number[] => {
   const invalidEventIndices = new Set<number>();
-  if (response.status === Status.Invalid && response.body) {
+  if (response.status === Status.Invalid && response.body !== undefined) {
     const { eventsWithInvalidFields, eventsWithMissingFields } = response.body;
     Object.keys(eventsWithInvalidFields).forEach((field: string) => {
       const eventIndices = eventsWithInvalidFields[field] ?? [];
@@ -26,7 +26,7 @@ export const collectInvalidEventIndices = (response: Response): Array<number> =>
     });
   }
 
-  return Array.from(invalidEventIndices).sort();
+  return Array.from(invalidEventIndices).sort((numberOne, numberTwo) => numberOne - numberTwo);
 };
 
 /**

--- a/packages/utils/src/response.ts
+++ b/packages/utils/src/response.ts
@@ -1,5 +1,6 @@
 import { Response, Status } from '@amplitude/types';
 import { IncomingMessage } from 'http';
+import { mapHttpCodeToStatus } from './status';
 
 /**
  * Collects the invalid event indices off a HTTP API v2 response
@@ -37,7 +38,7 @@ export const collectInvalidEventIndices = (response: Response): number[] => {
  */
 export const mapHttpMessageToResponse = (httpRes: IncomingMessage): Response => {
   const statusCode = httpRes.statusCode === undefined ? 0 : httpRes.statusCode;
-  const status = Status.fromHttpCode(statusCode);
+  const status = mapHttpCodeToStatus(statusCode);
 
   return {
     status,
@@ -57,7 +58,7 @@ export const mapJSONToResponse = (responseJSON: any): Response | null => {
     return null;
   }
 
-  const status = Status.fromHttpCode(responseJSON.code);
+  const status = mapHttpCodeToStatus(responseJSON.code);
   const statusCode = responseJSON.code;
 
   switch (status) {
@@ -77,10 +78,10 @@ export const mapJSONToResponse = (responseJSON: any): Response | null => {
         status,
         statusCode,
         body: {
-          error: responseJSON.error || '',
+          error: responseJSON.error ?? '',
           missingField: responseJSON.missing_field ?? null,
-          eventsWithInvalidFields: responseJSON.events_with_invalid_fields || {},
-          eventsWithMissingFields: responseJSON.events_with_missing_fields || {},
+          eventsWithInvalidFields: responseJSON.events_with_invalid_fields ?? {},
+          eventsWithMissingFields: responseJSON.events_with_missing_fields ?? {},
         },
       };
     case Status.PayloadTooLarge:
@@ -96,13 +97,13 @@ export const mapJSONToResponse = (responseJSON: any): Response | null => {
         status,
         statusCode,
         body: {
-          error: responseJSON.error || '',
+          error: responseJSON.error ?? '',
           epsThreshold: responseJSON.eps_threshold,
-          throttledDevices: responseJSON.throttled_devices || {},
-          throttledUsers: responseJSON.throttled_users || {},
-          exceededDailyQuotaDevices: responseJSON.exceeded_daily_quota_devices || {},
-          exceededDailyQuotaUsers: responseJSON.exceeded_daily_quota_users || {},
-          throttledEvents: responseJSON.throttled_events || [],
+          throttledDevices: responseJSON.throttled_devices ?? {},
+          throttledUsers: responseJSON.throttled_users ?? {},
+          exceededDailyQuotaDevices: responseJSON.exceeded_daily_quota_devices ?? {},
+          exceededDailyQuotaUsers: responseJSON.exceeded_daily_quota_users ?? {},
+          throttledEvents: responseJSON.throttled_events ?? [],
         },
       };
     default:

--- a/packages/utils/src/status.ts
+++ b/packages/utils/src/status.ts
@@ -1,0 +1,31 @@
+import { Status } from '@amplitude/types';
+
+/**
+ * Converts a HTTP status code into a {@link Status}.
+ *
+ * @param code The HTTP response status code.
+ * @returns The send status or {@link Status.Unknown}.
+ */
+export function mapHttpCodeToStatus(code: number): Status {
+  if (code >= 200 && code < 300) {
+    return Status.Success;
+  }
+
+  if (code === 429) {
+    return Status.RateLimit;
+  }
+
+  if (code === 413) {
+    return Status.PayloadTooLarge;
+  }
+
+  if (code >= 400 && code < 500) {
+    return Status.Invalid;
+  }
+
+  if (code >= 500) {
+    return Status.Failed;
+  }
+
+  return Status.Unknown;
+}


### PR DESCRIPTION
### Summary

Adheres to the tslint recommended eslint rules
 - only a few instances of floating promises where necessary (in setTimouts, and also to start the retry logic)
Move the `fromHttpCode` to `mapHttpCodeToStatus` in utils

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
