### PR TITLE
refactor(node): Max retries warning refactor

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -3,6 +3,9 @@ export { version as SDK_VERSION } from '../package.json';
 export const SDK_NAME = 'amplitude-node';
 export const AMPLITUDE_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
 export const BASE_RETRY_TIMEOUT_DEPRECATED = 100;
+export const BASE_RETRY_TIMEOUT_DEPRECATED_WARNING =
+  'DEPRECATED. Please use retryTimeouts. It will be converted to retryTimeouts with exponential wait times (i.e. 100ms -> 200ms -> 400ms -> ...)';
+
 // The overridable constants of the node SDK
 export const DEFAULT_OPTIONS: Options = {
   serverUrl: AMPLITUDE_SERVER_URL,

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -1,6 +1,6 @@
 import { Event, Options, Transport, TransportOptions, Payload, Status, Response, RetryClass } from '@amplitude/types';
 import { HTTPTransport } from './transports';
-import { DEFAULT_OPTIONS, BASE_RETRY_TIMEOUT_DEPRECATED } from './constants';
+import { DEFAULT_OPTIONS, BASE_RETRY_TIMEOUT_DEPRECATED, BASE_RETRY_TIMEOUT_DEPRECATED_WARNING } from './constants';
 import { asyncSleep, collectInvalidEventIndices, logger } from '@amplitude/utils';
 
 interface RetryMetadata {
@@ -37,9 +37,7 @@ export class RetryHandler implements RetryClass {
     this._options = Object.assign({}, DEFAULT_OPTIONS, options);
     this._transport = this._options.transportClass ?? this._setupDefaultTransport();
     if (this._options.maxRetries !== undefined) {
-      logger.warn(
-        'DEPRECATED: Please use retryTimeouts. It will be converted to retryTimeouts with exponential wait times (i.e. 100ms -> 200ms -> 400ms -> ...)',
-      );
+      logger.warn(BASE_RETRY_TIMEOUT_DEPRECATED_WARNING);
       this._options.retryTimeouts = convertMaxRetries(this._options.maxRetries);
       delete this._options.maxRetries;
     }

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -1,7 +1,8 @@
 import { TestRetry, MOCK_RETRY_TIMEOUTS } from './mocks/retry';
 import { MockTransport } from './mocks/transport';
 import { Event, Status, Response, Options } from '@amplitude/types';
-import { asyncSleep } from '@amplitude/utils';
+import { asyncSleep, logger } from '@amplitude/utils';
+import { BASE_RETRY_TIMEOUT_DEPRECATED_WARNING } from '../src/constants';
 
 const FAILING_USER_ID = 'data_monster';
 const PASSING_USER_ID = 'node_monster';
@@ -68,10 +69,13 @@ describe('retry mechanisms layer', () => {
     expect(transport.passCount).toBe(1);
   });
 
-  it('will convert deprecated options.maxRetries to options.retryTimeouts', async () => {
+  it('will convert deprecated options.maxRetries to options.retryTimeouts', () => {
+    const loggerSpy = jest.spyOn(logger, 'warn');
     const { retry } = generateRetryHandler(null, { maxRetries: 3 });
+    expect(loggerSpy).toHaveBeenCalledWith(BASE_RETRY_TIMEOUT_DEPRECATED_WARNING);
     expect(retry.getOptions().maxRetries).toBeUndefined();
     expect(retry.getOptions().retryTimeouts).toEqual([100, 200, 400]);
+    loggerSpy.mockRestore();
   });
 
   describe('fast-stop mechanisms for payloads', () => {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Forgot to include this change before merging #48 

- Refactor `options.maxRetries` deprecation warning string to constant
- Update tests to make sure warning is called
<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
