### PR TITLE
fix(dependency): Move `@amplitude/eslint-config-typescript` to dev dependencies

### DIFF
--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -16,12 +16,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@amplitude/eslint-config-typescript": "^1.1.0",
     "@amplitude/types": "^1.1.0",
     "@amplitude/utils": "^1.1.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@amplitude/eslint-config-typescript": "^1.1.0",
     "@types/jest": "^26.0.10",
     "eslint": "^7.0.0",
     "jest": "^26.4.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,12 +16,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@amplitude/eslint-config-typescript": "^1.1.0",
     "@amplitude/types": "^1.1.0",
     "@amplitude/utils": "^1.1.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@amplitude/eslint-config-typescript": "^1.1.0",
     "@types/jest": "^26.0.14",
     "@types/node": "^13.11.1",
     "eslint": "^7.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@amplitude/eslint-config-typescript": "^1.1.0",
     "@types/jest": "^26.0.14",
     "eslint": "^7.0.0",
     "jest": "^26.5.3",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,11 +16,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@amplitude/eslint-config-typescript": "^1.1.0",
     "@amplitude/types": "^1.1.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@amplitude/eslint-config-typescript": "^1.1.0",
     "@types/jest": "^26.0.14",
     "@types/jsdom": "^16.2.5",
     "eslint": "^7.0.0",


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Removes an unnecessary dependency from the build packages of some packages. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
