### PR TITLE
feat(min_id_length): Add support and tests for new SDK option `minIdLength`

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -21,4 +21,5 @@ export const DEFAULT_OPTIONS: Options = {
   transportClass: null,
   // By default, events flush on the next event loop
   uploadIntervalInSec: 0,
+  minIdLength: null,
 };

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -113,7 +113,7 @@ export class RetryHandler implements RetryClass {
     return prunedEvents;
   }
 
-  private _getPayloadOptions(): PayloadOptions {
+  private _getPayloadOptions(): { options?: PayloadOptions } {
     if (typeof this._options.minIdLength === 'number') {
       return {
         options: {

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -103,19 +103,23 @@ export class RetryHandler implements RetryClass {
     return prunedEvents;
   }
 
-  private _getPayload(events: readonly Event[]): Payload {
-    const payload = {
-      api_key: this._apiKey,
-      events,
-    };
-
-    if (this._options.minIdLength !== null) {
-      payload.options = {
-        min_id_length: this._options.minIdLength,
+  private _getPayloadOptions(): Partial<Payload> {
+    if (typeof this._options.minIdLength === 'number') {
+      return {
+        options: {
+          min_id_length: this._options.minIdLength,
+        },
       };
     }
+    return {};
+  }
 
-    return payload;
+  protected _getPayload(events: readonly Event[]): Payload {
+    return {
+      api_key: this._apiKey,
+      events,
+      ...this._getPayloadOptions(),
+    };
   }
 
   private _getRetryBuffer(userId: string, deviceId: string): Event[] | null {

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -104,10 +104,18 @@ export class RetryHandler implements RetryClass {
   }
 
   private _getPayload(events: readonly Event[]): Payload {
-    return {
+    const payload = {
       api_key: this._apiKey,
       events,
     };
+
+    if (this._options.minIdLength !== null) {
+      payload.options = {
+        min_id_length: this._options.minIdLength,
+      };
+    }
+
+    return payload;
   }
 
   private _getRetryBuffer(userId: string, deviceId: string): Event[] | null {

--- a/packages/node/src/retryHandler.ts
+++ b/packages/node/src/retryHandler.ts
@@ -1,4 +1,14 @@
-import { Event, Options, Transport, TransportOptions, Payload, Status, Response, RetryClass } from '@amplitude/types';
+import {
+  Event,
+  Options,
+  Transport,
+  TransportOptions,
+  Payload,
+  PayloadOptions,
+  Status,
+  Response,
+  RetryClass,
+} from '@amplitude/types';
 import { HTTPTransport } from './transports';
 import { DEFAULT_OPTIONS, BASE_RETRY_TIMEOUT_DEPRECATED, BASE_RETRY_TIMEOUT_DEPRECATED_WARNING } from './constants';
 import { asyncSleep, collectInvalidEventIndices, logger } from '@amplitude/utils';
@@ -103,7 +113,7 @@ export class RetryHandler implements RetryClass {
     return prunedEvents;
   }
 
-  private _getPayloadOptions(): Partial<Payload> {
+  private _getPayloadOptions(): PayloadOptions {
     if (typeof this._options.minIdLength === 'number') {
       return {
         options: {

--- a/packages/node/test/mocks/retry.ts
+++ b/packages/node/test/mocks/retry.ts
@@ -1,5 +1,5 @@
 import { RetryHandler } from '../../src/';
-import { Transport, Options } from '@amplitude/types';
+import { Transport, Options, Payload, Event } from '@amplitude/types';
 
 // Reduce default retryTimeouts for faster tests
 export const MOCK_RETRY_TIMEOUTS = [100, 100, 100];
@@ -17,5 +17,9 @@ export class TestRetry extends RetryHandler {
 
   public getOptions(): Partial<Options> {
     return { ...this._options };
+  }
+
+  public getPayload(events: readonly Event[]): Payload {
+    return this._getPayload(events);
   }
 }

--- a/packages/node/test/mocks/transport.ts
+++ b/packages/node/test/mocks/transport.ts
@@ -19,6 +19,7 @@ export class TestTransport extends HTTPTransport {
     return await this.sendPayload({
       api_key: 'NOT_A_REAL_API_KEY',
       events: [],
+      options: {},
     });
   }
 }

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -78,6 +78,23 @@ describe('retry mechanisms layer', () => {
     loggerSpy.mockRestore();
   });
 
+  it('will include the payload options key containing min_length_id if options.minLengthId is provided', () => {
+    const minIdLength = 5;
+    const { retry } = generateRetryHandler(undefined, { minIdLength });
+    const payload = retry.getPayload([generateEvent(PASSING_USER_ID)]);
+    expect(Object.keys(payload)).toEqual(['api_key', 'events', 'options']);
+    expect(payload.options).toEqual({ min_id_length: minIdLength });
+  });
+
+  it('will NOT include the payload options key if options.minLengthId is null or undefined', () => {
+    for (const minIdLength of [null, undefined]) {
+      const { retry } = generateRetryHandler(undefined, { minIdLength });
+      const payload = retry.getPayload([generateEvent(PASSING_USER_ID)]);
+      expect(Object.keys(payload)).not.toContain('options');
+      expect(payload.options).toBeUndefined();
+    }
+  });
+
   describe('fast-stop mechanisms for payloads', () => {
     it('will not allow a events exceeding daily quota to be retried', async () => {
       const body: Response = {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -39,12 +39,19 @@ export interface Event {
 }
 
 /**
- * Amplitude request payload definition.
+ * Amplitude request payload options.
  */
-export interface Payload {
-  api_key: string;
-  events: readonly Event[];
+
+export interface PayloadOptions {
   options?: {
     min_id_length?: number;
   };
+}
+
+/**
+ * Amplitude request payload definition.
+ */
+export interface Payload extends PayloadOptions {
+  api_key: string;
+  events: readonly Event[];
 }

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -44,4 +44,7 @@ export interface Event {
 export interface Payload {
   api_key: string;
   events: readonly Event[];
+  options?: {
+    min_id_length: number;
+  };
 }

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -45,6 +45,6 @@ export interface Payload {
   api_key: string;
   events: readonly Event[];
   options?: {
-    min_id_length: number;
+    min_id_length?: number;
   };
 }

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -43,9 +43,7 @@ export interface Event {
  */
 
 export interface PayloadOptions {
-  options?: {
-    min_id_length?: number;
-  };
+  min_id_length?: number;
 }
 
 /**
@@ -54,4 +52,5 @@ export interface PayloadOptions {
 export interface Payload extends PayloadOptions {
   api_key: string;
   events: readonly Event[];
+  options?: PayloadOptions;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,7 +1,7 @@
 export { LogLevel } from './logger';
 export { Client } from './client';
 export { Identity, IdentityListener, DEFAULT_IDENTITY_INSTANCE } from './identity';
-export { Event, Payload } from './event';
+export { Event, Payload, PayloadOptions } from './event';
 export { Options } from './options';
 export { Response, ResponseBody, SKIPPED_RESPONSE } from './response';
 export { RetryClass } from './retry';

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -62,5 +62,5 @@ export interface Options {
    * Optional parameter allowing users to set minimum permitted length for user_id & device_id fields
    * As described here: https://developers.amplitude.com/docs/http-api-v2#schemaRequestOptions
    */
-  minIdLength: number | null;
+  minIdLength?: number | null;
 }

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -57,4 +57,10 @@ export interface Options {
 
   /** The events upload interval */
   uploadIntervalInSec: number;
+
+  /**
+   * Optional parameter allowing users to set minimum permitted length for user_id & device_id fields
+   * As described here: https://developers.amplitude.com/docs/http-api-v2#schemaRequestOptions
+   */
+  minIdLength: number | null;
 }


### PR DESCRIPTION
### Summary

This implements the behavior requested in #64 

This PR adds a new option to the Node SDK, `options.minIdLength -> number | null | undefined`.  It also adds the necessary logic to append the `options: { minIdLength: x }` key:value pair to the payload send to the HTTP api.

Adds 2 tests to confirm that the payload being sent is modified correctly based on minIdLength being passed as an option, aswell as confirming that the payload is untouched if minIdLength is null or undefined.


### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
