### PR TITLE
feat(identify): identifyGroup groupIdentify API for Identify

### DIFF
--- a/packages/identify/README.md
+++ b/packages/identify/README.md
@@ -52,6 +52,9 @@ This identify supports the `setGroup` function.
 Any identify operation calls made on this object will **also** be treated as a group identify call.
 Certain operations will not be transferred to the group properties (see the docs on the [Group Identify API](https://developers.amplitude.com/docs/group-identify-api) to see which properties are supported here).
 
+To not associate a user with the group identify, you can also use the `identifyGroup` function to send `$groupIdentify`
+events for a group.
+
 ## Clear All
 
 Clear all will clear all user properties from the user and device on all events going forward.

--- a/packages/identify/src/identify.ts
+++ b/packages/identify/src/identify.ts
@@ -5,7 +5,7 @@ import {
   ValidPropertyType,
   SpecialEventType,
 } from '@amplitude/types';
-import { logger } from '@amplitude/utils';
+import { logger, generateBase36Id } from '@amplitude/utils';
 
 import { UNSET_VALUE, USER_IDENTIFY_OPERATIONS } from './constants';
 
@@ -32,6 +32,17 @@ export class Identify {
     if (deviceId !== null && deviceId.length > 0) {
       identifyEvent.device_id = deviceId;
     }
+
+    return identifyEvent;
+  }
+
+  public identifyGroup(groupName: string, groupValue: string): IdentifyEvent {
+    const identifyEvent: IdentifyEvent = {
+      event_type: SpecialEventType.GROUP_IDENTIFY,
+      groups: { [groupName]: groupValue },
+      user_properties: this.getUserProperties(),
+      device_id: generateBase36Id(), // Generate a throw-away, non-colliding ID
+    };
 
     return identifyEvent;
   }

--- a/packages/identify/src/identify.ts
+++ b/packages/identify/src/identify.ts
@@ -7,7 +7,7 @@ import {
 } from '@amplitude/types';
 import { logger, generateBase36Id } from '@amplitude/utils';
 
-import { UNSET_VALUE, USER_IDENTIFY_OPERATIONS } from './constants';
+import { UNSET_VALUE, USER_IDENTIFY_OPERATIONS, GROUP_IDENTIFY_OPERATIONS } from './constants';
 
 // A specific helper for the identify field
 const identifyWarn = (operation: IdentifyOperation, ...msgs: any[]): void => {
@@ -40,7 +40,7 @@ export class Identify {
     const identifyEvent: IdentifyEvent = {
       event_type: SpecialEventType.GROUP_IDENTIFY,
       groups: { [groupName]: groupValue },
-      user_properties: this.getUserProperties(),
+      user_properties: this.getGroupUserProperties(),
       device_id: generateBase36Id(), // Generate a throw-away, non-colliding ID
     };
 
@@ -50,6 +50,17 @@ export class Identify {
   protected getUserProperties(): IdentifyUserProperties {
     const userPropertiesCopy: IdentifyUserProperties = {};
     for (const field of USER_IDENTIFY_OPERATIONS) {
+      if (field in this._properties) {
+        userPropertiesCopy[field] = this._properties[field];
+      }
+    }
+
+    return userPropertiesCopy;
+  }
+
+  protected getGroupUserProperties(): IdentifyUserProperties {
+    const userPropertiesCopy: IdentifyUserProperties = {};
+    for (const field of GROUP_IDENTIFY_OPERATIONS) {
       if (field in this._properties) {
         userPropertiesCopy[field] = this._properties[field];
       }

--- a/packages/identify/tests/identify.spec.ts
+++ b/packages/identify/tests/identify.spec.ts
@@ -4,6 +4,8 @@ import { Identify } from '../src/identify';
 
 const USER_ID = 'MOCK_USER_ID';
 const DEVICE_ID = 'MOCK_DEVICE_ID';
+const GROUP_NAME = 'MOCK_GROUP_NAME';
+const GROUP_VALUE = 'MOCK_GROUP_VALUE';
 
 describe('Identify API', () => {
   it('should create an identify event with the correct top-level fields', () => {
@@ -13,6 +15,16 @@ describe('Identify API', () => {
     expect(event.device_id).toBe(DEVICE_ID);
     expect(event.user_id).toBe(USER_ID);
     expect(event.event_type).toBe(SpecialEventType.IDENTIFY);
+  });
+
+  it('should create a group identify event with the correct top-level fields', () => {
+    const identify = new Identify();
+    const event = identify.identifyGroup(GROUP_NAME, GROUP_VALUE);
+
+    expect(event.device_id !== undefined).toBe(true);
+    expect(event.user_id).toBe(undefined);
+    expect(event.event_type).toBe(SpecialEventType.GROUP_IDENTIFY);
+    expect(event.groups).toStrictEqual({ [GROUP_NAME]: GROUP_VALUE });
   });
   it('should see user property when using set', () => {
     const identify = new Identify();
@@ -188,5 +200,15 @@ describe('Identify API', () => {
     const expectedProperties = {};
 
     expect(event.user_properties).toStrictEqual(expectedProperties);
+  });
+
+  it('should ignore group identify properties that are not supported', () => {
+    const identify = new Identify();
+    identify.remove('PROPERTY_NAME', 'PROPERTY_VALUE');
+    identify.postInsert('PROPERTY_NAME', 'PROPERTY_VALUE');
+    identify.preInsert('PROPERTY_NAME', 'PROPERTY_VALUE');
+    const event = identify.identifyGroup(GROUP_NAME, GROUP_VALUE);
+
+    expect(event.user_properties).toStrictEqual({});
   });
 });


### PR DESCRIPTION
### Summary

Adds `$groupIdentify` events to the identify SDK, allowing the Node SDK to more easily create group identify events.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
