### PR TITLE
feat(validation): tougher rules on validate for device/user id

### DIFF
--- a/packages/utils/src/validate.ts
+++ b/packages/utils/src/validate.ts
@@ -7,8 +7,21 @@ export const isValidEvent = (event: Event): boolean => {
     return false;
   }
 
-  if (event.device_id === undefined && event.user_id === undefined) {
+  const hasDeviceId = event.device_id !== undefined;
+  const hasUserId = event.user_id !== undefined;
+
+  if (!hasDeviceId && !hasUserId) {
     logger.warn('Invalid event: expected at least one of device or user id');
+    return false;
+  }
+
+  if (hasDeviceId && typeof event.device_id !== 'string') {
+    logger.warn('Invalid event: expected device id to be a string if present');
+    return false;
+  }
+
+  if (hasUserId && typeof event.user_id !== 'string') {
+    logger.warn('Invalid event: expected user id to be a string if present');
     return false;
   }
 

--- a/packages/utils/test/validate.test.ts
+++ b/packages/utils/test/validate.test.ts
@@ -4,8 +4,8 @@ import { isValidEvent } from '../src/validate';
 describe('isValidEvent', () => {
   it('should pass on valid events with device id', () => {
     const validEvent: Event = {
-      event_type: 'NOT_A_REAL_EVENT_TYPE',
-      device_id: 'NOT_A_REAL_DEVICE_ID',
+      event_type: 'VALID_BUT_FAKE_EVENT_TYPE',
+      device_id: 'VALID_BUT_FAKE_DEVICE_ID',
     };
 
     expect(isValidEvent(validEvent)).toBe(true);
@@ -13,27 +13,45 @@ describe('isValidEvent', () => {
 
   it('should pass on valid events with user id', () => {
     const validEvent: Event = {
-      event_type: 'NOT_A_REAL_EVENT_TYPE',
-      user_id: 'NOT_A_REAL_USER_ID',
+      event_type: 'VALID_BUT_FAKE_EVENT_TYPE',
+      user_id: 'VALID_BUT_FAKE_USER_ID',
     };
 
     expect(isValidEvent(validEvent)).toBe(true);
   });
 
   it('should fail on valid events with no user or device id', () => {
-    const validEvent: Event = {
-      event_type: 'NOT_A_REAL_EVENT_TYPE',
+    const invalidEvent: Event = {
+      event_type: 'VALID_BUT_FAKE_EVENT_TYPE',
     } as any;
 
-    expect(isValidEvent(validEvent)).toBe(false);
+    expect(isValidEvent(invalidEvent)).toBe(false);
   });
 
   it('should fail on valid events with an invalid event type', () => {
-    const validEvent: Event = {
+    const invalidEvent: Event = {
       event_type: 3,
-      user_id: 'NOT_A_REAL_USER_ID',
+      user_id: 'VALID_BUT_FAKE_USER_ID',
     } as any;
 
-    expect(isValidEvent(validEvent)).toBe(false);
+    expect(isValidEvent(invalidEvent)).toBe(false);
+  });
+
+  it('should fail on valid events with an invalid user id', () => {
+    const invalidEvent: Event = {
+      event_type: 'VALID_BUT_FAKE_EVENT_TYPE',
+      user_id: 3,
+    } as any;
+
+    expect(isValidEvent(invalidEvent)).toBe(false);
+  });
+
+  it('should fail on valid events with an invalid device id', () => {
+    const invalidEvent: Event = {
+      event_type: 'VALID_BUT_FAKE_EVENT_TYPE',
+      device_id: 3,
+    } as any;
+
+    expect(isValidEvent(invalidEvent)).toBe(false);
   });
 });


### PR DESCRIPTION

### Summary

Adds a check to make sure user and device ID's are the correct type (will fail if numeric)

Helps debug #63 (dataPL ticket tracked internally)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
