### PR TITLE
fix(retry): BaseRetryHandler + Make Retry in general easier to play with

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -31,7 +31,8 @@ One of the important aspects and functionalities of the Node SDK is its **abilit
 Network requests can fail for a variety of reasons, and it is important that the SDK provides a layer of **robustness** and **correctness** when these failures happen.
 
 By default, the Node SDK will retry events on loop after a short pause if it finds that a request has failed; however, this
-strategy is not ideal for every use case. As such, you can provide your own `retryClass` so long as it implements a `sendEventsWithRetry` function. For example, there is a secondary `OfflineRetryHandler` that is meant for a more opinionated use case where network requests may not always be available for long periods of time:
+strategy is not ideal for every use case. As such, you can provide your own `retryClass` that implements the exported `Retry` interface (currently a single `sendEventsWithRetry` function).
+For example, there is a secondary `OfflineRetryHandler` that is meant for a more opinionated use case where network requests may not always be available for long periods of time:
 
 ```
 import { init, OfflineRetryHandler } from "@amplitude/node"
@@ -39,5 +40,6 @@ import { init, OfflineRetryHandler } from "@amplitude/node"
 const amplitudeClient = init('YOUR_API_KEY', { retryClass: new OfflineRetryHandler('YOUR_API_KEY') })
 ```
 
+As well as a `BaseRetryHandler` that does **no** retrying at all but contains several helper functions to extend from.
 ## Need Help?
 If you have any problems or issues over our SDK, feel free to [create a github issue](https://github.com/amplitude/Amplitude-Node/issues/new) or submit a request on [Amplitude Help](https://help.amplitude.com/hc/en-us/requests/new).

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,7 +1,8 @@
-export { Event, Options, Response, Status } from '@amplitude/types';
+export { Event, Options, Response, Status, Retry, Transport } from '@amplitude/types';
 export { NodeClient } from './nodeClient';
-export { RetryHandler } from './retry/defaultRetry';
+export { BaseRetryHandler } from './retry/baseRetry';
+export { RetryHandler, RetryHandler as DefaultRetryHandler } from './retry/defaultRetry';
 export { OfflineRetryHandler } from './retry/offlineRetry';
 
 export { init } from './sdk';
-export { HTTPTransport } from './transports';
+export { HTTPTransport, setupDefaultTransport } from './transports';

--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -1,5 +1,5 @@
 import { Identify } from '@amplitude/identify';
-import { Client, Event, Options, Response, RetryClass, SKIPPED_RESPONSE } from '@amplitude/types';
+import { Client, Event, Options, Response, Retry, SKIPPED_RESPONSE } from '@amplitude/types';
 import { logger, isNodeEnv, isValidEvent } from '@amplitude/utils';
 import { RetryHandler } from './retry/defaultRetry';
 import { SDK_NAME, SDK_VERSION, DEFAULT_OPTIONS } from './constants';
@@ -13,7 +13,7 @@ export class NodeClient implements Client<Options> {
 
   private _events: Event[] = [];
   private _responseListeners: Array<{ resolve: (response: Response) => void; reject: (err: Error) => void }> = [];
-  private readonly _transportWithRetry: RetryClass;
+  private readonly _transportWithRetry: Retry;
   private _flushTimer: NodeJS.Timeout | null = null;
 
   /**

--- a/packages/node/src/retry/baseRetry.ts
+++ b/packages/node/src/retry/baseRetry.ts
@@ -1,0 +1,47 @@
+import { Event, Options, Transport, Payload, PayloadOptions, Status, Response, Retry } from '@amplitude/types';
+import { setupDefaultTransport } from '../transports';
+import { DEFAULT_OPTIONS } from '../constants';
+
+export class BaseRetryHandler implements Retry {
+  protected readonly _apiKey: string;
+  protected readonly _options: Options;
+  protected readonly _transport: Transport;
+
+  public constructor(apiKey: string, options: Partial<Options> = {}) {
+    this._apiKey = apiKey;
+    this._options = { ...DEFAULT_OPTIONS, ...options };
+    this._transport = this._options.transportClass ?? setupDefaultTransport(this._options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async sendEventsWithRetry(events: readonly Event[]): Promise<Response> {
+    let response: Response = { status: Status.Unknown, statusCode: 0 };
+    response = await this._transport.sendPayload(this._getPayload(events));
+    if (response.status !== Status.Success) {
+      throw new Error(response.status);
+    }
+
+    return response;
+  }
+
+  protected _getPayloadOptions(): { options?: PayloadOptions } {
+    if (typeof this._options.minIdLength === 'number') {
+      return {
+        options: {
+          min_id_length: this._options.minIdLength,
+        },
+      };
+    }
+    return {};
+  }
+
+  protected _getPayload(events: readonly Event[]): Payload {
+    return {
+      api_key: this._apiKey,
+      events,
+      ...this._getPayloadOptions(),
+    };
+  }
+}

--- a/packages/node/src/retry/baseRetry.ts
+++ b/packages/node/src/retry/baseRetry.ts
@@ -19,10 +19,6 @@ export class BaseRetryHandler implements Retry {
   public async sendEventsWithRetry(events: readonly Event[]): Promise<Response> {
     let response: Response = { status: Status.Unknown, statusCode: 0 };
     response = await this._transport.sendPayload(this._getPayload(events));
-    if (response.status !== Status.Success) {
-      throw new Error(response.status);
-    }
-
     return response;
   }
 

--- a/packages/node/src/retry/offlineRetry.ts
+++ b/packages/node/src/retry/offlineRetry.ts
@@ -41,6 +41,7 @@ export class OfflineRetryHandler extends BaseRetryHandler {
     return {
       api_key: this._apiKey,
       events: this._eventsToRetry.concat(events),
+      ...this._getPayloadOptions(),
     };
   }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,6 @@ export { Identity, IdentityListener, DEFAULT_IDENTITY_INSTANCE } from './identit
 export { LogLevel } from './logger';
 export { Options } from './options';
 export { Response, ResponseBody, SKIPPED_RESPONSE } from './response';
-export { RetryClass } from './retry';
+export { RetryClass, Retry } from './retry';
 export { Status } from './status';
 export { Transport, TransportOptions, Payload, PayloadOptions } from './transport';

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -1,6 +1,6 @@
 import { LogLevel } from './logger';
 import { Transport } from './transport';
-import { RetryClass } from './retry';
+import { Retry } from './retry';
 
 /**
  * Options that you can choose to configure against the client.
@@ -45,7 +45,7 @@ export interface Options {
   /**
    * The class being used to handle event retrying.
    */
-  retryClass: RetryClass | null;
+  retryClass: Retry | null;
 
   /**
    * The class being used to transport events.

--- a/packages/types/src/retry.ts
+++ b/packages/types/src/retry.ts
@@ -2,7 +2,7 @@ import { Event } from './event';
 import { Response } from './response';
 
 /** Layer used to send data to Amplitude while retrying throttled events in the right order.  */
-export interface RetryClass {
+export interface Retry {
   /**
    * Send the events payload to Amplitude, and retry the events that failed on a loop.
    *
@@ -10,3 +10,8 @@ export interface RetryClass {
    */
   sendEventsWithRetry(events: readonly Event[]): Promise<Response>;
 }
+
+/**
+ * @deprecated a poor naming of an interface that should be implemented, NOT a class to extend.
+ */
+export type RetryClass = Retry;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -5,5 +5,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "types": ["node"]
-  }
+  },
+  "moduleResolution": "node"
 }


### PR DESCRIPTION

### Summary

Begins to address issues highlighted by #86 :

- exports `Retry` directly form `@amplitude/node` so that a second dep isn't necessary
- exports `BaseRetryHandler` that makes it easier to set up a default transport, etc.
- exports `DefaultTransport` 

- Exports `RetryClass` -> `Retry` in the `@amplitude/types` module to avoid confusion as this is an **interface** to implement and not a Class in itself. deprecating and still exporting `RetryClass` to avoid breaking changes (for now).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
