### PR TITLE
fix(event): no longer set platform field on every event

### DIFF
--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -129,7 +129,6 @@ export class NodeClient implements Client<Options> {
   /** Add platform dependent field onto event. */
   private _annotateEvent(event: Event): void {
     event.library = `${SDK_NAME}/${SDK_VERSION}`;
-    event.platform = event.platform ?? 'Node.js';
   }
 
   private _setupDefaultTransport(): RetryHandler {

--- a/packages/types/src/baseEvent.ts
+++ b/packages/types/src/baseEvent.ts
@@ -28,6 +28,11 @@ export interface BaseEvent {
   app_version?: string;
   version_name?: string;
   library?: string;
+
+  /** Optional
+   * Warning: updating any one of these fields will reset the other fields to null on the backend, unless the
+   * other fields are also set. See https://developers.amplitude.com/docs/http-api-v2 (Footnote 2) for more info
+   */
   platform?: string;
   os_name?: string;
   os_version?: string;

--- a/packages/types/src/baseEvent.ts
+++ b/packages/types/src/baseEvent.ts
@@ -19,9 +19,6 @@ export interface BaseEvent {
 
   // Optional
   time?: number;
-  country?: string;
-  region?: string;
-  city?: string;
   location_lat?: number;
   location_lng?: number;
 
@@ -30,8 +27,9 @@ export interface BaseEvent {
   library?: string;
 
   /** Optional
-   * Warning: updating any one of these fields will reset the other fields to null on the backend, unless the
-   * other fields are also set. See https://developers.amplitude.com/docs/http-api-v2 (Footnote 2) for more info
+   * Warning: updating any one of the following seven fields will reset the other fields
+   * to null on the backend, unless the other fields are also set.
+   * See https://developers.amplitude.com/docs/http-api-v2 (Footnote 2) for more info
    */
   platform?: string;
   os_name?: string;
@@ -41,13 +39,21 @@ export interface BaseEvent {
   device_model?: string;
   carrier?: string;
 
+  /** Optional
+   * Warning: updating any one of the following four fields will reset the other fields
+   * to null on the backend, unless the other fields are also set.
+   * See https://developers.amplitude.com/docs/http-api-v2 (Footnote 3) for more info
+   */
+  country?: string;
+  region?: string;
+  city?: string;
+  dma?: string; // ** The current Designated Market Area of the user. */
+
   idfa?: string;
   idfv?: string;
   adid?: string;
   android_id?: string;
 
-  // ** The current Designated Market Area of the user. */
-  dma?: string;
   language?: string;
   ip?: string;
   uuid?: string;


### PR DESCRIPTION
### Summary

No longer set platform field on every event. Doing so causes other fields to be nulled out, so this change will stop that from occurring by default (see https://developers.amplitude.com/docs/http-api-v2)


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: *No*
