### PR TITLE
ci(lint): add eslint prettier plugin, eslint/prettier CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --network-timeout 300000
 
       - name: Bootstrap
         run: yarn lerna bootstrap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
         run: yarn build
 
       - name: Test
-        run: yarn test
+        run: yarn test-since

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Lint (ESLint + Prettier)
+        run: yarn lint-since
+
       - name: Test
         run: yarn test-since

--- a/package.json
+++ b/package.json
@@ -31,7 +31,5 @@
     "prettier": "^1.17.0",
     "ts-jest": "^26.2.0"
   },
-  "dependencies": {
-    "husky": "^6.0.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "build:watch": "lerna run build:watch --stream --no-sort --concurrency 9999",
     "clean": "lerna run --stream clean && lerna clean --yes",
     "fix": "lerna run --stream --concurrency 1 fix",
+    "fix-since": "lerna run --since --stream --concurrency 1 fix",
     "link:yarn": "lerna run --stream --concurrency 1 link:yarn",
-    "lint": "lerna run --stream --concurrency 1 lint",
+    "lint": "lerna run --stream --concurrency 9999 lint",
+    "lint-since": "lerna run --since --stream --concurrency 9999 lint",
     "prepare": "yarn build",
     "test": "lerna run test --stream --concurrency 9999",
     "test-since": "lerna run test --since --stream --concurrency 9999"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "link:yarn": "lerna run --stream --concurrency 1 link:yarn",
     "lint": "lerna run --stream --concurrency 1 lint",
     "prepare": "yarn build",
-    "test": "lerna run test --stream --concurrency 9999"
+    "test": "lerna run test --stream --concurrency 9999",
+    "test-since": "lerna run test --since --stream --concurrency 9999"
   },
   "workspaces": [
     "packages/eslint-config-typescript",
@@ -27,5 +28,8 @@
     "lerna": "^3.20.2",
     "prettier": "^1.17.0",
     "ts-jest": "^26.2.0"
+  },
+  "dependencies": {
+    "husky": "^6.0.0"
   }
 }

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -9,6 +9,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'standard-with-typescript',
+    'prettier',
   ],
   globals: {
     Atomics: 'readonly',

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -19,5 +19,11 @@
   },
   "bugs": {
     "url": "https://github.com/amplitude/Amplitude-Node/issues"
+  },
+  "peerDependencies": {
+    "eslint": ">= 7"
+  },
+  "dependencies": {
+    "eslint-config-prettier": "^8.1.0"
   }
 }

--- a/packages/identify/.eslintrc.json
+++ b/packages/identify/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["@amplitude/typescript", "plugin:jest/recommended"],
   "plugins": ["jest"],
+  "ignorePatterns": ["jest.config.js", "/dist", "/esm"],
   "env": {
     "jest/globals": true
   }

--- a/packages/identity/.eslintrc.json
+++ b/packages/identity/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["@amplitude/eslint-config-typescript", "plugin:jest/recommended"],
   "plugins": ["jest"],
+  "ignorePatterns": ["jest.config.js", "/dist", "/esm"],
   "env": {
     "jest/globals": true
   }

--- a/packages/identity/test/identity.test.ts
+++ b/packages/identity/test/identity.test.ts
@@ -23,7 +23,7 @@ describe('default identity behavior', () => {
     expect(identity.getDeviceId().length).toBe(DEVICE_ID_LENGTH);
   });
 
-  it('should use the passed in device ID ', () => {
+  it('should use the passed in device ID', () => {
     const identity = new DefaultIdentity();
     identity.initializeDeviceId(DEVICE_ID);
 

--- a/packages/node/.eslintrc.json
+++ b/packages/node/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["@amplitude/eslint-config-typescript", "plugin:jest/recommended"],
   "plugins": ["jest"],
+  "ignorePatterns": ["jest.config.js", "/dist", "/esm"],
   "env": {
     "jest/globals": true
   }

--- a/packages/types/.eslintrc.json
+++ b/packages/types/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "@amplitude/eslint-config-typescript"
+  "extends": "@amplitude/eslint-config-typescript",
+  "ignorePatterns": ["jest.config.js", "/dist", "/esm"]
 }

--- a/packages/utils/.eslintrc.json
+++ b/packages/utils/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["@amplitude/eslint-config-typescript", "plugin:jest/recommended"],
   "plugins": ["jest"],
+  "ignorePatterns": ["jest.config.js", "/dist", "/esm"],
   "env": {
     "jest/globals": true
   }

--- a/packages/utils/src/validateProperties.ts
+++ b/packages/utils/src/validateProperties.ts
@@ -11,14 +11,14 @@ const _isValidObject = (properties: { [key: string]: any }): boolean => {
       logger.warn('invalid properties format. Skipping operation');
       return false;
     }
-    let value = properties[key];
+    const value = properties[key];
     if (!isValidProperties(key, value)) return false;
   }
   return true;
 };
 
 const isValidProperties = (property: string, value: any): boolean => {
-  if (typeof property != 'string') return false;
+  if (typeof property !== 'string') return false;
   if (Array.isArray(value)) {
     for (const valueElement of value) {
       if (Array.isArray(valueElement)) {

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -1,4 +1,5 @@
 import { isBrowserEnv, isNodeEnv, prototypeJsFix } from '@amplitude/utils';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { JSDOM, DOMWindow } from 'jsdom';
 
 // Augment built-ins APIs for prototypeJsFix tests
@@ -22,11 +23,13 @@ const processPlaceholder = global.process;
 
 function setupBrowserTest(): void {
   global.window = dom.window;
-  delete global.process;
+  // Note: Used to get around not being able to delete non-optional fields for the sake of testing
+  global.process = undefined as any;
 }
 
 function cleanupBrowserTest(): void {
-  delete global.window;
+  global.window = undefined as any;
+  // Note: Used to get around not being able to delete non-optional fields for the sake of testing
   global.process = processPlaceholder;
 }
 

--- a/packages/utils/test/queue.test.ts
+++ b/packages/utils/test/queue.test.ts
@@ -71,19 +71,18 @@ describe('async queue utility', () => {
     const hook = new PromiseHook();
     const queue = new AsyncQueue();
 
-    let didError = false;
     const firstPromise = queue.addToQueue<string>(async () => await Promise.reject(new Error('PROMISE_ONE')));
     const secondPromise = queue.addToQueue<string>(hook.createPromise('PROMISE_TWO'));
 
     expect(hook.lastPromiseTag).toBe(null);
 
+    let errorMessage = '';
     try {
       await firstPromise;
     } catch (err) {
-      expect(err.message).toBe('PROMISE_ONE');
-      didError = true;
+      errorMessage = err.message;
     }
-    expect(didError).toBe(true);
+    expect(errorMessage).toBe('PROMISE_ONE');
 
     await secondPromise;
     expect(hook.lastPromiseTag).toBe('PROMISE_TWO');

--- a/packages/utils/test/validateProperties.test.ts
+++ b/packages/utils/test/validateProperties.test.ts
@@ -14,7 +14,7 @@ describe('isValidateProperties', () => {
   });
 
   it('should fail on invalid properties with function as value', () => {
-    const testFunc = () => {
+    const testFunc = (): string => {
       return 'test';
     };
     const inValidProperties = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3271,6 +3271,11 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz#4ef1eaf97afe5176e6a75ddfb57c335121abc5a6"
+  integrity sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==
+
 eslint-config-standard-with-typescript@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-16.0.0.tgz#71418b9a3eb82ebff31cac67222562c683959ae4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,6 +4188,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
+  integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,11 +4188,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
-  integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
-
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
### Summary

Adds the prettier plugin which stops eslint and prettier from fighting in certain files.

Adds ESLint + Prettier as a breaking step in PR Validation, as well as cleans up a few eslint issues.

Next step is to get Prettier + ESLint working well with Husky (+ whatever the best practice is in Lerna/monorepos)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
