### PR TITLE
build: Reduce # of times packages get built, better specify tsconfig

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --network-timeout 300000
 
-      - name: Bootstrap
-        run: yarn lerna bootstrap
-
-      - name: Build
-        run: yarn build
-
       - name: Lint (ESLint + Prettier)
         run: yarn lint-since
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Check out Git repository
+      - name: Checkout Git Repository
         uses: actions/checkout@v2
 
       - name: Setup Node.js ${{ matrix.node-version }}
@@ -20,14 +20,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: yarn install --frozen-lockfile --network-timeout 300000 --ignore-scripts
 
-      - name: Bootstrap
+      - name: Bootstrap (Build Files + Link Dependents)
         run: yarn lerna bootstrap
 
       - name: Lint (ESLint + Prettier)
         run: yarn lint-since
 
-      - name: Test
+      - name: Run Unit Tests
         run: yarn test-since

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --network-timeout 300000
+        run: yarn install --frozen-lockfile --network-timeout 300000 --ignore-scripts
+
+      - name: Bootstrap
+        run: yarn lerna bootstrap
 
       - name: Lint (ESLint + Prettier)
         run: yarn lint-since

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -17,9 +17,10 @@ module.exports = {
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: './tsconfig.json',
     ecmaVersion: 2018,
+    project: '../../tsconfig.json',
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint'],
   rules: {


### PR DESCRIPTION
### Summary

The eslintrc will take the **working directory** as the top level for the typescript parser, unless specified. 

Also fixes an issue where the unit tests build the packages an unnecessary 3 times, because of the `prepare` script (which IMO we should still keep)

- The first time is during `yarn install --frozen-lockfile`. Since lerna doesn't have great tooling around giving subscripts flags when it runs install, decided to keep this step and add the `--ignore-scripts` flag to make sure it doesn't build
- Second time is during `lerna bootstrap`. Decided to keep this for the symlinking of depedencies and decided it was also easy enough to let this still run `prepare`.
- Third was an unnecessary `yarn build`. Just removed this.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
