### PR TITLE
ci: switch macOS environment to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        os: [macos-10.14, ubuntu-18.04]
+        os: [macOs-latest, ubuntu-18.04]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        os: [macOs-latest, ubuntu-18.04]
+        os: [macOS-latest, ubuntu-18.04]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION


### Summary

Changes the macOS-10.14 to macOS-latest, triggered when github noticed we weren't using the latest version

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
