### PR TITLE
feat(timeout): Make request timeout configurable

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -22,4 +22,6 @@ export const DEFAULT_OPTIONS: Options = {
   // By default, events flush on the next event loop
   uploadIntervalInSec: 0,
   minIdLength: null,
+  // By default, set the request timeout to 10 seconds.
+  requestCancelTimeout: 10000,
 };

--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -21,9 +21,6 @@ export interface HTTPRequest {
   ): http.ClientRequest;
 }
 
-// Automatially cancel requests that have been waiting for 10+ s
-const REQUEST_CANCEL_TIMEOUT = 10 * 1000;
-
 /** Base Transport class implementation */
 export class HTTPTransport implements Transport {
   /** The Agent used for corresponding transport */
@@ -34,6 +31,7 @@ export class HTTPTransport implements Transport {
 
   /** Create instance and set this.dsn */
   public constructor(public options: TransportOptions) {
+    this.options = options;
     if (options.serverUrl.startsWith('http://')) {
       this.module = http;
     } else if (options.serverUrl.startsWith('https://')) {
@@ -51,7 +49,7 @@ export class HTTPTransport implements Transport {
 
     // Queue up the call to send the payload.
     // Wait 10 seconds for each request in queue before removing it
-    return await this._requestQueue.addToQueue(call, REQUEST_CANCEL_TIMEOUT);
+    return await this._requestQueue.addToQueue(call, this.options.requestCancelTimeout);
   }
 
   /** Returns a build request option object used by request */
@@ -108,6 +106,7 @@ export class HTTPTransport implements Transport {
 
 export const setupDefaultTransport = (options: Options): Transport => {
   const transportOptions: TransportOptions = {
+    requestCancelTimeout: options.requestCancelTimeout,
     serverUrl: options.serverUrl,
     headers: {
       'Content-Type': 'application/json',

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -62,5 +62,8 @@ export interface Options {
    * Optional parameter allowing users to set minimum permitted length for user_id & device_id fields
    * As described here: https://developers.amplitude.com/docs/http-api-v2#schemaRequestOptions
    */
-  minIdLength?: number | null;
+  minIdLength: number | null;
+
+  /** If you'd like to configure a custom timeout for each request, set it here in milliseconds. */
+  requestCancelTimeout: number;
 }

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -34,4 +34,5 @@ export interface TransportOptions {
   serverUrl: string;
   /** Define custom headers */
   headers: { [key: string]: string };
+  requestCancelTimeout: number;
 }

--- a/packages/utils/src/validate.ts
+++ b/packages/utils/src/validate.ts
@@ -9,6 +9,7 @@ export const isValidEvent = (event: Event): boolean => {
 
   const hasDeviceId = event.device_id !== undefined;
   const hasUserId = event.user_id !== undefined;
+  const hasEventProperties = event.event_properties !== undefined;
 
   if (!hasDeviceId && !hasUserId) {
     logger.warn('Invalid event: expected at least one of device or user id');
@@ -22,6 +23,11 @@ export const isValidEvent = (event: Event): boolean => {
 
   if (hasUserId && typeof event.user_id !== 'string') {
     logger.warn('Invalid event: expected user id to be a string if present');
+    return false;
+  }
+
+  if (hasEventProperties && typeof event.event_properties !== 'object') {
+    logger.warn('Invalid event properties: expected event properties to be type object');
     return false;
   }
 

--- a/packages/utils/test/validate.test.ts
+++ b/packages/utils/test/validate.test.ts
@@ -54,4 +54,25 @@ describe('isValidEvent', () => {
 
     expect(isValidEvent(invalidEvent)).toBe(false);
   });
+
+  it('should pass on valid events and object for event properties', () => {
+    const validEvent: Event = {
+      event_type: 'VALID_BUT_FAKE_EVENT_TYPE',
+      device_id: 'VALID_BUT_FAKE_DEVICE_ID',
+      event_properties: {fake_but_valid_key: "fake_but_valid_value"},
+    };
+
+    expect(isValidEvent(validEvent)).toBe(true);
+  });
+
+  it('should fail on valid events with invalid event properties', () => {
+    const invalidEvent: Event = {
+      event_type: 'VALID_BUT_FAKE_EVENT_TYPE',
+      device_id: 'VALID_BUT_FAKE_DEVICE_ID',
+      event_properties: 3,
+    } as any;
+
+    expect(isValidEvent(invalidEvent)).toBe(false);
+  });
+
 });

--- a/packages/utils/test/validate.test.ts
+++ b/packages/utils/test/validate.test.ts
@@ -59,7 +59,7 @@ describe('isValidEvent', () => {
     const validEvent: Event = {
       event_type: 'VALID_BUT_FAKE_EVENT_TYPE',
       device_id: 'VALID_BUT_FAKE_DEVICE_ID',
-      event_properties: {fake_but_valid_key: "fake_but_valid_value"},
+      event_properties: { fake_but_valid_key: 'fake_but_valid_value' },
     };
 
     expect(isValidEvent(validEvent)).toBe(true);
@@ -74,5 +74,4 @@ describe('isValidEvent', () => {
 
     expect(isValidEvent(invalidEvent)).toBe(false);
   });
-
 });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!--
Allows users to set their own time duration for removing queued promises in queue.ts.  If no value is supplied by the user, the default 10 second request timeout should be used.

Follow-up: May want to update [options documentation here](https://developers.amplitude.com/docs/http-api-v2#options).
 -->

### Checklist

* [ Yes ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Not sure -->
