### PR TITLE
feat: allow identify to take both null user id and null device id

### DIFF
--- a/packages/identify/src/identify.ts
+++ b/packages/identify/src/identify.ts
@@ -21,16 +21,30 @@ export class Identify {
   protected _groups: { [groupName: string]: string } = {};
 
   /** Create a user identify event out of this identify */
-  public identifyUser(userId: string, deviceId: string | null = null): IdentifyEvent {
+  public identifyUser(userId: string | null, deviceId: string | null = null): IdentifyEvent {
     const identifyEvent: IdentifyEvent = {
       event_type: SpecialEventType.IDENTIFY,
       groups: { ...this._groups },
       user_properties: this.getUserProperties(),
-      user_id: userId,
     };
 
-    if (deviceId !== null && deviceId.length > 0) {
+    let hasUserId = false;
+    let hasDeviceId = false;
+
+    if (typeof userId === 'string' && userId.length > 0) {
+      hasUserId = true;
+      identifyEvent.user_id = userId;
+    }
+
+    if (typeof deviceId === 'string' && deviceId.length > 0) {
+      hasDeviceId = true;
       identifyEvent.device_id = deviceId;
+    }
+
+    if (!hasUserId && !hasDeviceId) {
+      logger.warn(
+        'Creating identify event without device or user ID - this event will be rejected unless one is attached',
+      );
     }
 
     return identifyEvent;

--- a/packages/identify/test/identify.spec.ts
+++ b/packages/identify/test/identify.spec.ts
@@ -22,7 +22,7 @@ describe('Identify API', () => {
     const event = identify.identifyUser(null, DEVICE_ID);
 
     expect(event.device_id).toBe(DEVICE_ID);
-    expect(event.user_id).toBe(null);
+    expect(event.user_id).toBe(undefined);
     expect(event.event_type).toBe(SpecialEventType.IDENTIFY);
   });
 
@@ -30,7 +30,7 @@ describe('Identify API', () => {
     const identify = new Identify();
     const event = identify.identifyUser(USER_ID, null);
 
-    expect(event.device_id).toBe(null);
+    expect(event.device_id).toBe(undefined);
     expect(event.user_id).toBe(USER_ID);
     expect(event.event_type).toBe(SpecialEventType.IDENTIFY);
   });

--- a/packages/identify/test/identify.spec.ts
+++ b/packages/identify/test/identify.spec.ts
@@ -17,6 +17,24 @@ describe('Identify API', () => {
     expect(event.event_type).toBe(SpecialEventType.IDENTIFY);
   });
 
+  it('should create an identify event even if user ID is null', () => {
+    const identify = new Identify();
+    const event = identify.identifyUser(null, DEVICE_ID);
+
+    expect(event.device_id).toBe(DEVICE_ID);
+    expect(event.user_id).toBe(null);
+    expect(event.event_type).toBe(SpecialEventType.IDENTIFY);
+  });
+
+  it('should create an identify event even if device ID is null', () => {
+    const identify = new Identify();
+    const event = identify.identifyUser(USER_ID, null);
+
+    expect(event.device_id).toBe(null);
+    expect(event.user_id).toBe(USER_ID);
+    expect(event.event_type).toBe(SpecialEventType.IDENTIFY);
+  });
+
   it('should create a group identify event with the correct top-level fields', () => {
     const identify = new Identify();
     const event = identify.identifyGroup(GROUP_NAME, GROUP_VALUE);

--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -116,7 +116,7 @@ export class NodeClient implements Client<Options> {
    * @param identify the Identify instance containing user property information
    * @returns a Promise containing metadata about the success of sending this identify to the Amplitude API
    */
-  public async identify(userId: string, deviceId: string, identify: Identify): Promise<Response> {
+  public async identify(userId: string | null, deviceId: string | null, identify: Identify): Promise<Response> {
     if (!(identify instanceof Identify)) {
       logger.warn('Invalid Identify object. Skipping operation.');
       return await Promise.resolve(SKIPPED_RESPONSE);


### PR DESCRIPTION
### Summary

Allow the identify to take null user and device ID, and give a warning if both are empty

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
