### PR TITLE
fix(identify): Send group properties instead of user properties for group identify

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,15 @@ This is Amplitude Node.js SDK written in Typescript, the 1st backend SDK for Amp
 ## Installation and Quick Start
 Please visit our :100:[Developer Center](https://developers.amplitude.com/docs/nodejs) for instructions on installing and using our the SDK.
 
+## Check Out the Sub-Packages
+
+In order of what might be good to read to get acquainted with the Node SDK:
+
+- [(`@amplitude/node`)](https://github.com/amplitude/Amplitude-Node/tree/main/packages/node): The core Node SDK and a starting place for logging events in Node.js.
+- [(`@amplitude/types`)](https://github.com/amplitude/Amplitude-Node/tree/main/packages/types): Contains our helper types and enums(What an event looks like, what to expect the response to look like). A resource for interfacing with the Node SDK.
+- [(`@amplitude/identify`)](https://github.com/amplitude/Amplitude-Node/tree/main/packages/identify): A builder-type class that helps interface with the Identify API and the Node SDK. Use it to compose Identify events for both users and groups.
+- [(`@amplitude/identity`)](https://github.com/amplitude/Amplitude-Node/tree/main/packages/identity): A helper class to store the "identity" (device + user ID) of a certain event or client.
+- [(`@amplitude/utils`)](https://github.com/amplitude/Amplitude-Node/tree/main/packages/utils): A list of shared (mostly) polymorphic utilities across our javascript-based SDK's.
+- [("@amplitude/eslint-config-typescript`)](https://github.com/amplitude/Amplitude-Node/tree/main/packages/eslint-config-typescript): The ESLint configuration shared across our repositories.
 ## Need Help?
 If you have any problems or issues over our SDK, feel free to [create a github issue](https://github.com/amplitude/Amplitude-Node/issues/new) or submit a request on [Amplitude Help](https://help.amplitude.com/hc/en-us/requests/new).

--- a/packages/identify/src/identify.ts
+++ b/packages/identify/src/identify.ts
@@ -1,5 +1,6 @@
 import {
   IdentifyEvent,
+  GroupIdentifyEvent,
   IdentifyOperation,
   IdentifyUserProperties,
   ValidPropertyType,
@@ -50,11 +51,11 @@ export class Identify {
     return identifyEvent;
   }
 
-  public identifyGroup(groupName: string, groupValue: string): IdentifyEvent {
-    const identifyEvent: IdentifyEvent = {
+  public identifyGroup(groupName: string, groupValue: string): GroupIdentifyEvent {
+    const identifyEvent: GroupIdentifyEvent = {
       event_type: SpecialEventType.GROUP_IDENTIFY,
       groups: { [groupName]: groupValue },
-      user_properties: this.getGroupUserProperties(),
+      group_properties: this.getGroupUserProperties(),
       device_id: generateBase36Id(), // Generate a throw-away, non-colliding ID
     };
 

--- a/packages/identify/test/identify.spec.ts
+++ b/packages/identify/test/identify.spec.ts
@@ -37,12 +37,18 @@ describe('Identify API', () => {
 
   it('should create a group identify event with the correct top-level fields', () => {
     const identify = new Identify();
+    identify.set('PROPERTY_NAME', 'PROPERTY_VALUE');
+
     const event = identify.identifyGroup(GROUP_NAME, GROUP_VALUE);
+    const expectedProperties = {
+      [IdentifyOperation.SET]: { PROPERTY_NAME: 'PROPERTY_VALUE' },
+    };
 
     expect(event.device_id !== undefined).toBe(true);
     expect(event.user_id).toBe(undefined);
     expect(event.event_type).toBe(SpecialEventType.GROUP_IDENTIFY);
     expect(event.groups).toStrictEqual({ [GROUP_NAME]: GROUP_VALUE });
+    expect(event.group_properties).toStrictEqual(expectedProperties);
   });
   it('should see user property when using set', () => {
     const identify = new Identify();

--- a/packages/identify/test/identify.spec.ts
+++ b/packages/identify/test/identify.spec.ts
@@ -233,6 +233,6 @@ describe('Identify API', () => {
     identify.preInsert('PROPERTY_NAME', 'PROPERTY_VALUE');
     const event = identify.identifyGroup(GROUP_NAME, GROUP_VALUE);
 
-    expect(event.user_properties).toStrictEqual({});
+    expect(event.group_properties).toStrictEqual({});
   });
 });

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -1,4 +1,4 @@
 import { BaseEvent } from './baseEvent';
-import { IdentifyEvent } from './identify';
+import { IdentifyEvent, GroupIdentifyEvent } from './identify';
 
-export type Event = BaseEvent | IdentifyEvent;
+export type Event = BaseEvent | IdentifyEvent | GroupIdentifyEvent;

--- a/packages/types/src/identify.ts
+++ b/packages/types/src/identify.ts
@@ -46,8 +46,17 @@ export interface IdentifyUserProperties {
 }
 
 export interface IdentifyEvent extends BaseEvent {
-  event_type: SpecialEventType.IDENTIFY | SpecialEventType.GROUP_IDENTIFY;
+  event_type: SpecialEventType.IDENTIFY;
   user_properties:
+    | IdentifyUserProperties
+    | {
+        [key in Exclude<string, IdentifyOperation>]: any;
+      };
+}
+
+export interface GroupIdentifyEvent extends BaseEvent {
+  event_type: SpecialEventType.GROUP_IDENTIFY;
+  group_properties:
     | IdentifyUserProperties
     | {
         [key in Exclude<string, IdentifyOperation>]: any;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,7 +1,13 @@
 export { BaseEvent, SpecialEventType } from './baseEvent';
 export { Client } from './client';
 export { Event } from './event';
-export { IdentifyEvent, IdentifyOperation, IdentifyUserProperties, ValidPropertyType } from './identify';
+export {
+  IdentifyEvent,
+  GroupIdentifyEvent,
+  IdentifyOperation,
+  IdentifyUserProperties,
+  ValidPropertyType,
+} from './identify';
 export { Identity, IdentityListener, DEFAULT_IDENTITY_INSTANCE } from './identity';
 export { LogLevel } from './logger';
 export { Options } from './options';


### PR DESCRIPTION

### Summary

Group Identify was sending the wrong field - fix that

Also add a linking of READMES at the Top Level

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
