### PR TITLE
feat: onRetry lifecycle callback

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -22,4 +22,5 @@ export const DEFAULT_OPTIONS: Options = {
   // By default, events flush on the next event loop
   uploadIntervalInSec: 0,
   minIdLength: null,
+  onRetry: undefined,
 };

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -22,5 +22,5 @@ export const DEFAULT_OPTIONS: Options = {
   // By default, events flush on the next event loop
   uploadIntervalInSec: 0,
   minIdLength: null,
-  onRetry: undefined,
+  onRetry: null,
 };

--- a/packages/node/src/retry/defaultRetry.ts
+++ b/packages/node/src/retry/defaultRetry.ts
@@ -241,7 +241,7 @@ export class RetryHandler extends BaseRetryHandler {
         eventsToRetry,
       );
       if (this._options.onRetry !== null && response.status !== Status.Success)
-        this._options.onRetry(response, numRetries);
+        this._options.onRetry(response, numRetries, numRetries === this._options.retryTimeouts.length - 1);
 
       if (eventIndicesToRemove.length > 0) {
         let numEventsRemoved = 0;

--- a/packages/node/src/retry/defaultRetry.ts
+++ b/packages/node/src/retry/defaultRetry.ts
@@ -240,7 +240,7 @@ export class RetryHandler extends BaseRetryHandler {
         deviceId,
         eventsToRetry,
       );
-      if (this._options.onRetry !== null && response.status !== Status.Success)
+      if (this._options.onRetry !== null)
         this._options.onRetry(response, numRetries, numRetries === this._options.retryTimeouts.length - 1);
 
       if (eventIndicesToRemove.length > 0) {

--- a/packages/node/src/retry/defaultRetry.ts
+++ b/packages/node/src/retry/defaultRetry.ts
@@ -240,7 +240,8 @@ export class RetryHandler extends BaseRetryHandler {
         deviceId,
         eventsToRetry,
       );
-      if (this._options.onRetry && response.status !== Status.Success) this._options.onRetry(response, numRetries);
+      if (this._options.onRetry !== null && response.status !== Status.Success)
+        this._options.onRetry(response, numRetries);
 
       if (eventIndicesToRemove.length > 0) {
         let numEventsRemoved = 0;

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -75,6 +75,21 @@ describe('default retry mechanisms', () => {
     expect(onRetry.mock.calls[2][0]).toBe(response);
   });
 
+  it('should not call onRetry lifecycle callback after retries', async () => {
+    const onRetry = jest.fn();
+    const { retry } = generateRetryHandler(null, {
+      onRetry,
+      retryTimeouts: [50, 100, 200],
+    });
+    const payload = [generateEvent(PASSING_USER_ID)];
+
+    await retry.sendEventsWithRetry(payload);
+
+    // Sleep and wait for retries to end
+    await asyncSleep(500);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
   it('will not throttle user ids that are not throttled', async () => {
     const { transport, retry } = generateRetryHandler();
     const payload = [generateEvent(FAILING_USER_ID), generateEvent(PASSING_USER_ID)];

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -63,7 +63,7 @@ describe('default retry mechanisms', () => {
     const response = await retry.sendEventsWithRetry(payload);
 
     // Sleep and wait for retries to end
-    await asyncSleep(500);
+    await asyncSleep(1000);
     expect(onRetry.mock.calls).toHaveLength(3);
     // Test retryTimeoutsIndex
     expect(onRetry.mock.calls[0][0]).toBe(response);
@@ -79,7 +79,7 @@ describe('default retry mechanisms', () => {
     expect(onRetry.mock.calls[2][2]).toBe(true);
   });
 
-  it('should not call onRetry lifecycle callback after retries', async () => {
+  it('should not call onRetry lifecycle callback after successful sends', async () => {
     const onRetry = jest.fn();
     const { retry } = generateRetryHandler(null, {
       onRetry,

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -66,13 +66,17 @@ describe('default retry mechanisms', () => {
     await asyncSleep(500);
     expect(onRetry.mock.calls).toHaveLength(3);
     // Test retryTimeoutsIndex
+    expect(onRetry.mock.calls[0][0]).toBe(response);
+    expect(onRetry.mock.calls[1][0]).toBe(response);
+    expect(onRetry.mock.calls[2][0]).toBe(response);
+
     expect(onRetry.mock.calls[0][1]).toBe(0);
     expect(onRetry.mock.calls[1][1]).toBe(1);
     expect(onRetry.mock.calls[2][1]).toBe(2);
 
-    expect(onRetry.mock.calls[0][0]).toBe(response);
-    expect(onRetry.mock.calls[1][0]).toBe(response);
-    expect(onRetry.mock.calls[2][0]).toBe(response);
+    expect(onRetry.mock.calls[0][2]).toBe(false);
+    expect(onRetry.mock.calls[1][2]).toBe(false);
+    expect(onRetry.mock.calls[2][2]).toBe(true);
   });
 
   it('should not call onRetry lifecycle callback after retries', async () => {

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -1,6 +1,7 @@
 import { LogLevel } from './logger';
 import { Transport } from './transport';
 import { Retry } from './retry';
+import { Response } from './response';
 
 /**
  * Options that you can choose to configure against the client.

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -71,5 +71,5 @@ export interface Options {
    * @param response Response from the given retry attempt
    * @param retryTimeoutsIndex Index in retryTimeouts for how long Amplitude waited before this retry attempt.
    */
-  onRetry?(response: Response, retryTimeoutsIndex: number): void;
+  onRetry: ((response: Response, retryTimeoutsIndex: number) => boolean) | null;
 }

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -69,7 +69,8 @@ export interface Options {
    * Lifecycle callback that is executed after a retry attempt. Called in {@link Retry.sendEventsWithRetry}
    *
    * @param response Response from the given retry attempt
-   * @param retryTimeoutsIndex Index in retryTimeouts for how long Amplitude waited before this retry attempt. Starts at 0.
+   * @param attemptNumber Index in retryTimeouts for how long Amplitude waited before this retry attempt. Starts at 0.
+   * @param isLastRetry True if attemptNumber === retryTimeouts.length - 1
    */
   onRetry: ((response: Response, attemptNumber: number, isLastRetry: boolean) => boolean) | null;
 }

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -71,5 +71,5 @@ export interface Options {
    * @param response Response from the given retry attempt
    * @param retryTimeoutsIndex Index in retryTimeouts for how long Amplitude waited before this retry attempt. Starts at 0.
    */
-  onRetry: ((response: Response, attemptNumber: number) => boolean) | null;
+  onRetry: ((response: Response, attemptNumber: number, isLastRetry: boolean) => boolean) | null;
 }

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -63,4 +63,12 @@ export interface Options {
    * As described here: https://developers.amplitude.com/docs/http-api-v2#schemaRequestOptions
    */
   minIdLength?: number | null;
+
+  /**
+   * Lifecycle callback that is executed after a retry attempt. Called in {@link Retry.sendEventsWithRetry}
+   *
+   * @param response Response from the given retry attempt
+   * @param retryTimeoutsIndex Index in retryTimeouts for how long Amplitude waited before this retry attempt.
+   */
+  onRetry?(response: Response, retryTimeoutsIndex: number): void;
 }

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -69,7 +69,7 @@ export interface Options {
    * Lifecycle callback that is executed after a retry attempt. Called in {@link Retry.sendEventsWithRetry}
    *
    * @param response Response from the given retry attempt
-   * @param retryTimeoutsIndex Index in retryTimeouts for how long Amplitude waited before this retry attempt.
+   * @param retryTimeoutsIndex Index in retryTimeouts for how long Amplitude waited before this retry attempt. Starts at 0.
    */
-  onRetry: ((response: Response, retryTimeoutsIndex: number) => boolean) | null;
+  onRetry: ((response: Response, attemptNumber: number) => boolean) | null;
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Adds a new option `onRetry` that allows that gives client access to information about retry attempts
  - Is a callback with params (response, retryTimeoutsIndex)
- Adds tests to validate when onRetry should or shouldn't be called

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
