### PR TITLE
fix(retry): Storing _eventsToRetry in OfflineRetryHandler

### DIFF
--- a/packages/node/src/retry/offlineRetry.ts
+++ b/packages/node/src/retry/offlineRetry.ts
@@ -21,7 +21,7 @@ export class OfflineRetryHandler extends BaseRetryHandler {
   public async sendEventsWithRetry(events: readonly Event[]): Promise<Response> {
     return await this._requestQueue.addToQueue(async () => {
       let response: Response = { status: Status.Unknown, statusCode: 0 };
-      const payload = this._getPayload(events)
+      const payload = this._getPayload(events);
 
       try {
         response = await this._transport.sendPayload(payload);

--- a/packages/node/src/retry/offlineRetry.ts
+++ b/packages/node/src/retry/offlineRetry.ts
@@ -21,16 +21,17 @@ export class OfflineRetryHandler extends BaseRetryHandler {
   public async sendEventsWithRetry(events: readonly Event[]): Promise<Response> {
     return await this._requestQueue.addToQueue(async () => {
       let response: Response = { status: Status.Unknown, statusCode: 0 };
+      const payload = this._getPayload(events)
 
       try {
-        response = await this._transport.sendPayload(this._getPayload(events));
+        response = await this._transport.sendPayload(payload);
         if (response.status !== Status.Success) {
           throw new Error(response.status);
         } else {
           this._onSendSuccess();
         }
       } catch {
-        this._onSendError(events, response);
+        this._onSendError(payload.events, response);
       }
 
       return response;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

If my understanding of the idea behind OfflineRetryHandler is right then this PR fixes a bug regarding storing `_eventsToRetry`

### Details

Events passed to `_onSendError` where only events from the current batch (flush). But OfflineRetryHandler tries to send events from the current batch concatenated with `_eventsToRetry`. As a result:
- only events from the last batch had a chance to be stored in `_eventsToRetry` and after one attempt to send them again they were gone, no matter what was the result of the request.
- I assume the line `newEventsToRetry = events.filter((_, index) => !invalidEventIndices.has(index));` wasn't working properly as `invalidEventIndices` were computed based on events that were send (`_eventsToRetry.concat(events)`) and not `events`. **Edit** that's my assumption about how API works

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
