### PR TITLE
fix: Amp 41577 timeout fix

### DIFF
--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -6,6 +6,8 @@ export const BASE_RETRY_TIMEOUT_DEPRECATED = 100;
 export const BASE_RETRY_TIMEOUT_DEPRECATED_WARNING =
   'DEPRECATED. Please use retryTimeouts. It will be converted to retryTimeouts with exponential wait times (i.e. 100ms -> 200ms -> 400ms -> ...)';
 
+export const REQUEST_TIMEOUT_MILLIS_DEFAULT = 10000;
+
 // The overridable constants of the node SDK
 export const DEFAULT_OPTIONS: Options = {
   serverUrl: AMPLITUDE_SERVER_URL,
@@ -24,5 +26,5 @@ export const DEFAULT_OPTIONS: Options = {
   minIdLength: null,
   onRetry: null,
   // Default 10 second event timeout
-  requestTimeoutMillis: 10000,
+  requestTimeoutMillis: REQUEST_TIMEOUT_MILLIS_DEFAULT,
 };

--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -3,6 +3,7 @@ import { AsyncQueue, mapJSONToResponse, mapHttpMessageToResponse } from '@amplit
 
 import * as http from 'http';
 import * as https from 'https';
+import { REQUEST_TIMEOUT_MILLIS_DEFAULT } from '../constants';
 import * as url from 'url';
 
 /**
@@ -44,8 +45,9 @@ export class HTTPTransport implements Transport {
   /**
    * @inheritDoc
    */
-  public async sendPayload(payload: Payload, limitInMs = this.options.requestTimeoutMillis): Promise<Response> {
-    const call = async (): Promise<Response> => await this._sendWithModule(payload, limitInMs);
+  public async sendPayload(payload: Payload, limitInMs?: number): Promise<Response> {
+    const timeoutMS = limitInMs ?? this.options.requestTimeoutMillis ?? REQUEST_TIMEOUT_MILLIS_DEFAULT;
+    const call = async (): Promise<Response> => await this._sendWithModule(payload, timeoutMS);
 
     // Queue up the call to send the payload.
     // Wait 10 seconds for each request in queue before removing it

--- a/packages/node/test/http.test.ts
+++ b/packages/node/test/http.test.ts
@@ -13,7 +13,6 @@ describe('HTTPTransport tests', () => {
       headers: {
         'Content-Type': 'application/json',
       },
-      requestTimeoutMillis: DEFAULT_OPTIONS.requestTimeoutMillis,
     };
     const httpTransport = new HTTPTransport(transportOptions);
 

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -35,5 +35,5 @@ export interface TransportOptions {
   /** Define custom headers */
   headers: { [key: string]: string };
   /** Configurable request timeout */
-  requestTimeoutMillis: number;
+  requestTimeoutMillis?: number;
 }


### PR DESCRIPTION
### Summary

Fixes issue where custom transport implementations break w/o `requestTimeoutMillis`, which should be an optional parameter

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
