### PR TITLE
fix(Identify): Ensure boolean is allowed as a valid property value

### DIFF
--- a/packages/utils/src/validateProperties.ts
+++ b/packages/utils/src/validateProperties.ts
@@ -26,14 +26,14 @@ const isValidProperties = (property: string, value: any): boolean => {
         return false;
       } else if (typeof valueElement === 'object') {
         return _isValidObject(value);
-      } else if (!(typeof valueElement === 'number' || typeof valueElement === 'string') || !(typeof valueElement === 'boolean')) {
+      } else if (!(typeof valueElement === 'number' || typeof valueElement === 'string' || typeof valueElement === 'boolean')) {
         logger.warn('invalid array element type ', typeof valueElement);
         return false;
       }
     }
   } else if (typeof value === 'object') {
     return _isValidObject(value);
-  } else if (!(typeof value === 'number' || typeof value === 'string')) {
+  } else if (!(typeof value === 'number' || typeof value === 'string') || (typeof value === 'boolean')) {
     logger.warn('invalid value type ', typeof value);
     return false;
   }

--- a/packages/utils/src/validateProperties.ts
+++ b/packages/utils/src/validateProperties.ts
@@ -35,7 +35,7 @@ const isValidProperties = (property: string, value: any): boolean => {
     }
   } else if (typeof value === 'object') {
     return _isValidObject(value);
-  } else if (!(typeof value === 'number' || typeof value === 'string') || typeof value === 'boolean') {
+  } else if (!(typeof value === 'number' || typeof value === 'string' || typeof value === 'boolean')) {
     logger.warn('invalid value type ', typeof value);
     return false;
   }

--- a/packages/utils/src/validateProperties.ts
+++ b/packages/utils/src/validateProperties.ts
@@ -26,14 +26,16 @@ const isValidProperties = (property: string, value: any): boolean => {
         return false;
       } else if (typeof valueElement === 'object') {
         return _isValidObject(value);
-      } else if (!(typeof valueElement === 'number' || typeof valueElement === 'string' || typeof valueElement === 'boolean')) {
+      } else if (
+        !(typeof valueElement === 'number' || typeof valueElement === 'string' || typeof valueElement === 'boolean')
+      ) {
         logger.warn('invalid array element type ', typeof valueElement);
         return false;
       }
     }
   } else if (typeof value === 'object') {
     return _isValidObject(value);
-  } else if (!(typeof value === 'number' || typeof value === 'string') || (typeof value === 'boolean')) {
+  } else if (!(typeof value === 'number' || typeof value === 'string') || typeof value === 'boolean') {
     logger.warn('invalid value type ', typeof value);
     return false;
   }

--- a/packages/utils/src/validateProperties.ts
+++ b/packages/utils/src/validateProperties.ts
@@ -26,7 +26,7 @@ const isValidProperties = (property: string, value: any): boolean => {
         return false;
       } else if (typeof valueElement === 'object') {
         return _isValidObject(value);
-      } else if (!(typeof valueElement === 'number' || typeof valueElement === 'string')) {
+      } else if (!(typeof valueElement === 'number' || typeof valueElement === 'string') || !(typeof valueElement === 'boolean')) {
         logger.warn('invalid array element type ', typeof valueElement);
         return false;
       }

--- a/packages/utils/test/validateProperties.test.ts
+++ b/packages/utils/test/validateProperties.test.ts
@@ -4,7 +4,7 @@ describe('isValidateProperties', () => {
     const validProperties = {
       keyForString: 'stringValue',
       keyForNumber: 123,
-      keyForArray: ['test', 456, { arrayObjKey1: 'arrayObjValue1' }],
+      keyForArray: ['test', 456, { arrayObjKey1: 'arrayObjValue1' }, false],
       keyForObj: {
         objKey1: 'objValue1',
         objKey2: 'objValue2',
@@ -33,7 +33,7 @@ describe('isValidateProperties', () => {
     const validProperties = {
       keyForString: 'stringValue',
       keyForNumber: 123,
-      keyForArray: ['test', 456],
+      keyForArray: ['test', 456, false],
       keyForObj: {
         objKey1: 'objValue1',
         objKey2: 'objValue2',

--- a/packages/utils/test/validateProperties.test.ts
+++ b/packages/utils/test/validateProperties.test.ts
@@ -9,6 +9,7 @@ describe('isValidateProperties', () => {
         objKey1: 'objValue1',
         objKey2: 'objValue2',
       },
+      keyForBoolean: false,
     };
     expect(isValidProperties('property', validProperties)).toBe(true);
   });
@@ -37,6 +38,7 @@ describe('isValidateProperties', () => {
         objKey1: 'objValue1',
         objKey2: 'objValue2',
       },
+      keyForBoolean: false,
     };
     expect(isValidProperties(1 as any, validProperties)).toBe(false);
   });


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Node SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixes https://github.com/amplitude/Amplitude-Node/issues/116. There was another [PR](https://github.com/amplitude/Amplitude-Node/pull/124) which added `boolean` as a valid type, but it didn't fix the core problem. This PR does and updates the tests to account for `boolean` as a valid value type.

Here is the original issue that was reported: https://github.com/amplitude/Amplitude-Node/issues/116

### Checklist

* [ x ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
