### PR TITLE
fix: middleware is now run prior to event validation

### DIFF
--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -92,14 +92,6 @@ export class NodeClient implements Client<Options> {
       return await Promise.resolve(SKIPPED_RESPONSE);
     }
 
-    if (!isValidEvent(event)) {
-      logger.warn('Found invalid event - skipping logEvent action.');
-      return await Promise.resolve(SKIPPED_RESPONSE);
-    }
-
-    this._annotateEvent(event);
-    this._observeEvent(event);
-
     let middlewareCompleted = false;
     this._middlewareRunner.run({ event, extra }, () => {
       middlewareCompleted = true;
@@ -109,6 +101,14 @@ export class NodeClient implements Client<Options> {
       logger.warn('Middleware chain skipped logEvent action.');
       return await Promise.resolve(SKIPPED_RESPONSE);
     }
+
+    if (!isValidEvent(event)) {
+      logger.warn('Found invalid event - skipping logEvent action.');
+      return await Promise.resolve(SKIPPED_RESPONSE);
+    }
+
+    this._annotateEvent(event);
+    this._observeEvent(event);
 
     return await new Promise((resolve, reject) => {
       // Add event to unsent events queue.

--- a/packages/node/src/nodeClient.ts
+++ b/packages/node/src/nodeClient.ts
@@ -92,6 +92,9 @@ export class NodeClient implements Client<Options> {
       return await Promise.resolve(SKIPPED_RESPONSE);
     }
 
+    this._annotateEvent(event);
+    this._observeEvent(event);
+
     let middlewareCompleted = false;
     this._middlewareRunner.run({ event, extra }, () => {
       middlewareCompleted = true;
@@ -106,9 +109,6 @@ export class NodeClient implements Client<Options> {
       logger.warn('Found invalid event - skipping logEvent action.');
       return await Promise.resolve(SKIPPED_RESPONSE);
     }
-
-    this._annotateEvent(event);
-    this._observeEvent(event);
 
     return await new Promise((resolve, reject) => {
       // Add event to unsent events queue.


### PR DESCRIPTION
### Summary
Middleware is now run prior to event validation in logEvent(). This allows middleware to enrich invalid events prior to validation.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
