### PR TITLE
fix: Add try catch around retry sendPayload() to handle errors on retry

### DIFF
--- a/packages/node/src/retry/defaultRetry.ts
+++ b/packages/node/src/retry/defaultRetry.ts
@@ -229,7 +229,7 @@ export class RetryHandler extends BaseRetryHandler {
           status: Status.SystemError,
           statusCode: 0,
           error: err instanceof Error ? err : new Error(String(err)),
-        }
+        },
       };
     }
   }

--- a/packages/node/test/retry.test.ts
+++ b/packages/node/test/retry.test.ts
@@ -246,8 +246,12 @@ describe('default retry mechanisms', () => {
     const payload = [generateEvent(PASSING_USER_ID)];
     const response = await retry.sendEventsWithRetry(payload);
 
+    // Sleep and wait for retries to end
+    await asyncSleep(1000);
+
     expect(response.status).toBe(Status.SystemError);
     expect(response.statusCode).toBe(0);
+    expect(sendPayloadSpy).toBeCalledTimes(2);
     sendPayloadSpy.mockRestore();
   });
 });


### PR DESCRIPTION
### Summary

* Add try catch for `ErrnoException` thrown in `_retryEventsOnce()`. Fixes https://github.com/amplitude/Amplitude-Node/issues/154.

* Fix unit test to include a wait on retry to complete before exiting

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
