### PR TITLE
feat(transport): Allow using a custom port in URI

### DIFF
--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -67,6 +67,7 @@ export class HTTPTransport implements Transport {
       headers,
       method: 'POST',
       hostname: url.hostname,
+      port: url.port,
       path: url.pathname,
     };
 

--- a/packages/node/test/http.test.ts
+++ b/packages/node/test/http.test.ts
@@ -88,4 +88,29 @@ describe('HTTPTransport tests', () => {
       sendPayloadSpy.mockRestore();
     });
   });
+
+  describe('sendPayload test with different port', () => {
+    const SERVER_URL = 'https://localhost:3000/2/httpapi';
+    const transportOptions = {
+      serverUrl: SERVER_URL,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+    const httpTransport = new HTTPTransport(transportOptions);
+
+    it('should succeed under default settings (no timeout delay)', async () => {
+      nock(SERVER_URL)
+        .post(anyMatch)
+        .reply(200);
+
+      const testPayload = {
+        api_key: 'test',
+        events: [],
+      };
+      const resp = await httpTransport.sendPayload(testPayload);
+      expect(resp.status).toBe(Status.Success);
+      expect(resp.statusCode).toBe(200);
+    });
+  });
 });


### PR DESCRIPTION
### Summary
Allow using a custom port in the URI. The code changes add support for extracting the port from the URI and setting it if one is given.

Our use-case: we proxy requests to Amplitude through our own endpoint. So in dev environment, it is helpful to be able to override the port in the URI.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
