### PR TITLE
feat(transport): Meaningful result on empty API response

### DIFF
--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -92,9 +92,12 @@ export class HTTPTransport implements Transport {
           }
           if (res.complete && rawData.length > 0) {
             try {
-              const responseWithBody = mapJSONToResponse(JSON.parse(rawData));
-              if (responseWithBody !== null) {
-                return resolve(responseWithBody);
+              const content = JSON.parse(rawData);
+              if (Object.keys(content).length > 0) {
+                const responseWithBody = mapJSONToResponse(content);
+                if (responseWithBody !== null) {
+                  return resolve(responseWithBody);
+                }
               }
             } catch {
               // pass


### PR DESCRIPTION
### Summary
Ensure that the correct HTTP response code gets propagated when the response contains an empty JSON object.

e.g. ensures that a 400 response with empty payload is returned to the client as `{ "statusCode": 400, "name": "invalid" }`, rather than the confusing default `{ "statusCode": 0, "name": "unknown" }`

Can replicate this by sending an identify event with more than 10 elements in a `groups` entry.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Node/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
